### PR TITLE
Update HTMX URL push, preserve date-filter redirect, and harden theme toggle script

### DIFF
--- a/src/main/resources/templates/entries/list.html
+++ b/src/main/resources/templates/entries/list.html
@@ -37,6 +37,7 @@
             hx-get="/entries/fragments/table"
             hx-target="#table-container"
             hx-swap="outerHTML"
+            hx-push-url="true"
             hx-trigger="change from:#filter-account, change from:#filter-category">
             <div class="grid-2">
                 <div class="field">
@@ -76,7 +77,8 @@
                     th:action="@{/entries}"
                     hx-get="/entries/fragments/table"
                     hx-target="#table-container"
-                    hx-swap="outerHTML">
+                    hx-swap="outerHTML"
+                    hx-push-url="true">
                     <input type="hidden" name="accountId" th:value="${selectedAccountId}">
                     <input type="hidden" name="categoryId" th:value="${selectedCategoryId}">
                     <input type="hidden" name="page" value="0">
@@ -101,7 +103,8 @@
                     th:action="@{/entries}"
                     hx-get="/entries/fragments/table"
                     hx-target="#table-container"
-                    hx-swap="outerHTML">
+                    hx-swap="outerHTML"
+                    hx-push-url="true">
                     <input type="hidden" name="accountId" th:value="${selectedAccountId}">
                     <input type="hidden" name="categoryId" th:value="${selectedCategoryId}">
                     <input type="hidden" name="size" th:value="${pagination.pageSize}">

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -76,9 +76,9 @@
     </div>
 
     <div class="wrap period-filter-wrap">
-        <form class="period-filter" method="post" th:action="@{/date-filter}">
+        <form class="period-filter" method="post" th:action="@{/date-filter}" id="period-filter-form">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-            <input type="hidden" name="redirectTo" th:value="${currentPath}">
+            <input type="hidden" name="redirectTo" th:value="${currentPath}" id="period-filter-redirect-to">
 
             <div class="period-filter-row">
                 <span class="period-filter-label" th:text="#{dateFilter.label}"></span>
@@ -145,45 +145,53 @@
         (function () {
             const key = "aisha-theme";
             const themeToggle = document.getElementById("theme-toggle");
-            if (!themeToggle) {
-                return;
-            }
+            const periodFilterForm = document.getElementById("period-filter-form");
+            const periodFilterRedirectInput = document.getElementById("period-filter-redirect-to");
 
-            const themeToggleLabel = themeToggle.querySelector('[data-role="label"]');
-            const themeIconDark = themeToggle.querySelector('[data-role="icon-dark"]');
-            const themeIconLight = themeToggle.querySelector('[data-role="icon-light"]');
+            if (themeToggle) {
+                const themeToggleLabel = themeToggle.querySelector('[data-role="label"]');
+                const themeIconDark = themeToggle.querySelector('[data-role="icon-dark"]');
+                const themeIconLight = themeToggle.querySelector('[data-role="icon-light"]');
 
-            function readCurrentTheme() {
-                return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
-            }
-
-            function updateToggleLabel() {
-                const currentTheme = readCurrentTheme();
-                const nextTheme = currentTheme === "dark" ? "light" : "dark";
-                const label = nextTheme === "dark"
-                    ? themeToggle.dataset.labelDark
-                    : themeToggle.dataset.labelLight;
-
-                if (themeToggleLabel) {
-                    themeToggleLabel.textContent = label;
+                function readCurrentTheme() {
+                    return document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
                 }
-                if (themeIconDark && themeIconLight) {
-                    themeIconDark.hidden = nextTheme !== "dark";
-                    themeIconLight.hidden = nextTheme !== "light";
-                }
-                themeToggle.setAttribute("aria-pressed", String(currentTheme === "dark"));
-            }
 
-            themeToggle.addEventListener("click", () => {
-                const currentTheme = readCurrentTheme();
-                const nextTheme = currentTheme === "dark" ? "light" : "dark";
-                document.documentElement.setAttribute("data-theme", nextTheme);
-                localStorage.setItem(key, nextTheme);
-                window.dispatchEvent(new CustomEvent("aisha-theme-changed", { detail: { theme: nextTheme } }));
+                function updateToggleLabel() {
+                    const currentTheme = readCurrentTheme();
+                    const nextTheme = currentTheme === "dark" ? "light" : "dark";
+                    const label = nextTheme === "dark"
+                        ? themeToggle.dataset.labelDark
+                        : themeToggle.dataset.labelLight;
+
+                    if (themeToggleLabel) {
+                        themeToggleLabel.textContent = label;
+                    }
+                    if (themeIconDark && themeIconLight) {
+                        themeIconDark.hidden = nextTheme !== "dark";
+                        themeIconLight.hidden = nextTheme !== "light";
+                    }
+                    themeToggle.setAttribute("aria-pressed", String(currentTheme === "dark"));
+                }
+
+                themeToggle.addEventListener("click", () => {
+                    const currentTheme = readCurrentTheme();
+                    const nextTheme = currentTheme === "dark" ? "light" : "dark";
+                    document.documentElement.setAttribute("data-theme", nextTheme);
+                    localStorage.setItem(key, nextTheme);
+                    window.dispatchEvent(new CustomEvent("aisha-theme-changed", { detail: { theme: nextTheme } }));
+                    updateToggleLabel();
+                });
+
                 updateToggleLabel();
-            });
+            }
 
-            updateToggleLabel();
+            if (periodFilterForm && periodFilterRedirectInput) {
+                periodFilterForm.addEventListener("submit", () => {
+                    periodFilterRedirectInput.value = `${window.location.pathname}${window.location.search}`;
+                });
+            }
+
         }());
     </script>
 </header>


### PR DESCRIPTION
### Motivation
- Ensure client-side HTMX interactions update the browser URL so filters and pagination are reflected in history and shareable links.
- Preserve the current page location when submitting the global date filter so redirects return users to the same view.
- Make the theme toggle script more robust and ensure labels/icons reflect the new state immediately after toggling.

### Description
- Added `hx-push-url="true"` to the entries list filter form, the pagination size form, and the pagination navigation form so HTMX swaps also push the URL state.
- Added `id="period-filter-form"` and `id="period-filter-redirect-to"` to the period filter form and hidden `redirectTo` input to allow JS to update the redirect target before submit.
- Refactored the header script to guard DOM access, move theme-related elements inside a `themeToggle` existence check, call `updateToggleLabel()` after changing the theme, and update icon visibility and `aria-pressed` consistently.
- Added an event listener on the period filter form to populate the `redirectTo` hidden input with the current `window.location.pathname` and `window.location.search` at submit time.

### Testing
- Ran backend unit test suite with `mvn test` and the tests completed successfully. 
- Executed UI/template smoke checks for the affected pages including entries list filtering and pagination, and they passed in automated runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a366d1a1e083328caf7a06de3c2d58)