### PR TITLE
Fix PostgreSQL failure when opening entries page with description filter

### DIFF
--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapter.java
@@ -19,9 +19,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class EntryRepositoryAdapter implements EntryRepository {
 
-    private static final String ACCENTED_CHARACTERS = "ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ";
-    private static final String PLAIN_CHARACTERS = "AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn";
-
     private final JpaEntryRepository jpaEntryRepository;
 
     public EntryRepositoryAdapter(JpaEntryRepository jpaEntryRepository) {
@@ -50,8 +47,6 @@ public class EntryRepositoryAdapter implements EntryRepository {
             onlyWithoutCategory,
             onlyPendingCategorySuggestions,
             EntryCategorySuggestionStatus.PENDING,
-            ACCENTED_CHARACTERS,
-            PLAIN_CHARACTERS,
             pageRequest
         );
         return new PagedResult<>(

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepository.java
@@ -28,7 +28,14 @@ public interface JpaEntryRepository extends JpaRepository<Entry, Long> {
           )
           and (
                 :descriptionFilter is null
-                or upper(function('translate', e.description, :accentedCharacters, :plainCharacters))
+                or upper(
+                    function(
+                        'translate',
+                        e.description,
+                        'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ',
+                        'AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn'
+                    )
+                )
                     like concat(
                         '%',
                         :descriptionFilter,
@@ -48,8 +55,6 @@ public interface JpaEntryRepository extends JpaRepository<Entry, Long> {
         @Param("onlyWithoutCategory") boolean onlyWithoutCategory,
         @Param("onlyPendingCategorySuggestions") boolean onlyPendingCategorySuggestions,
         @Param("pendingStatus") EntryCategorySuggestionStatus pendingStatus,
-        @Param("accentedCharacters") String accentedCharacters,
-        @Param("plainCharacters") String plainCharacters,
         Pageable pageable
     );
 

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapterTest.java
@@ -38,8 +38,6 @@ class EntryRepositoryAdapterTest {
             anyBoolean(),
             anyBoolean(),
             any(EntryCategorySuggestionStatus.class),
-            anyString(),
-            anyString(),
             any(Pageable.class)
         )).thenReturn(Page.empty());
 
@@ -65,8 +63,6 @@ class EntryRepositoryAdapterTest {
             anyBoolean(),
             anyBoolean(),
             any(EntryCategorySuggestionStatus.class),
-            anyString(),
-            anyString(),
             any(Pageable.class)
         );
 

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepositoryTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepositoryTest.java
@@ -22,9 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @TestPropertySource(properties = "spring.sql.init.mode=never")
 class JpaEntryRepositoryTest {
 
-    private static final String ACCENTED_CHARACTERS = "ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ";
-    private static final String PLAIN_CHARACTERS = "AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn";
-
     @Autowired
     private JpaEntryRepository jpaEntryRepository;
 
@@ -49,8 +46,6 @@ class JpaEntryRepositoryTest {
             false,
             false,
             EntryCategorySuggestionStatus.PENDING,
-            ACCENTED_CHARACTERS,
-            PLAIN_CHARACTERS,
             PageRequest.of(0, 25)
         );
 


### PR DESCRIPTION
### Motivation
- Production requests to `GET /entries` failed with `DataIntegrityViolationException: invalid input syntax for type bytea` when the description filter was used, caused by passing the accent-mapping strings as query parameters to `translate()` in JPQL. 
- The intent is to keep accent- and case-insensitive description searches while avoiding the parameter binding problem on PostgreSQL.

### Description
- Inlined the accented and plain character maps directly into the JPQL `function('translate', ...)` call in `JpaEntryRepository` to avoid binding the maps as parameters. 
- Removed the now-unnecessary `accentedCharacters` and `plainCharacters` parameters from the `searchBySettlementDateBetweenAndFilters` repository method signature and updated the method invocation in `EntryRepositoryAdapter`. 
- Removed the corresponding constants from `EntryRepositoryAdapter` and updated unit/integration tests to match the new repository signature and behavior. 
- Updated `JpaEntryRepositoryTest` and `EntryRepositoryAdapterTest` to remove the translate map parameters and to continue asserting the normalized filter behavior.

### Testing
- Executed the full test suite with `mvn test` and the build completed successfully with all tests passing (BUILD SUCCESS, 131 tests run). 
- Ran the modified repository unit and integration tests (`JpaEntryRepositoryTest`, `EntryRepositoryAdapterTest`) as part of the suite and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a05d16688332a3ba57b0cd21a233)