### PR TITLE
Handle blank description filter and add query variant without description

### DIFF
--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapter.java
@@ -19,9 +19,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class EntryRepositoryAdapter implements EntryRepository {
 
-    private static final String ACCENTED_CHARACTERS = "ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ";
-    private static final String PLAIN_CHARACTERS = "AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn";
-
     private final JpaEntryRepository jpaEntryRepository;
 
     public EntryRepositoryAdapter(JpaEntryRepository jpaEntryRepository) {
@@ -41,19 +38,29 @@ public class EntryRepositoryAdapter implements EntryRepository {
         int pageSize
     ) {
         PageRequest pageRequest = PageRequest.of(page, pageSize);
-        Page<Entry> result = jpaEntryRepository.searchBySettlementDateBetweenAndFilters(
-            startDate,
-            endDate,
-            accountId,
-            categoryId,
-            normalizeDescriptionFilter(descriptionFilter),
-            onlyWithoutCategory,
-            onlyPendingCategorySuggestions,
-            EntryCategorySuggestionStatus.PENDING,
-            ACCENTED_CHARACTERS,
-            PLAIN_CHARACTERS,
-            pageRequest
-        );
+        String normalizedDescriptionFilter = normalizeDescriptionFilter(descriptionFilter);
+        Page<Entry> result = normalizedDescriptionFilter == null
+            ? jpaEntryRepository.searchBySettlementDateBetweenAndFiltersWithoutDescription(
+                startDate,
+                endDate,
+                accountId,
+                categoryId,
+                onlyWithoutCategory,
+                onlyPendingCategorySuggestions,
+                EntryCategorySuggestionStatus.PENDING,
+                pageRequest
+            )
+            : jpaEntryRepository.searchBySettlementDateBetweenAndFilters(
+                startDate,
+                endDate,
+                accountId,
+                categoryId,
+                normalizedDescriptionFilter,
+                onlyWithoutCategory,
+                onlyPendingCategorySuggestions,
+                EntryCategorySuggestionStatus.PENDING,
+                pageRequest
+            );
         return new PagedResult<>(
             result.getContent(),
             result.getNumber(),
@@ -155,6 +162,10 @@ public class EntryRepositoryAdapter implements EntryRepository {
 
     private String normalizeDescriptionFilter(String value) {
         if (value == null) {
+            return null;
+        }
+
+        if (value.isBlank()) {
             return null;
         }
 

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepository.java
@@ -26,9 +26,42 @@ public interface JpaEntryRepository extends JpaRepository<Entry, Long> {
                 (:onlyWithoutCategory = true and e.category is null)
                 or (:onlyWithoutCategory = false and (:categoryId is null or e.category.id = :categoryId))
           )
+          and (:onlyPendingCategorySuggestions = false or e.categorySuggestionStatus = :pendingStatus)
+        order by e.settlementDate desc, e.id desc
+        """
+    )
+    Page<Entry> searchBySettlementDateBetweenAndFiltersWithoutDescription(
+        LocalDate startDate,
+        LocalDate endDate,
+        @Param("accountId") Long accountId,
+        @Param("categoryId") Long categoryId,
+        @Param("onlyWithoutCategory") boolean onlyWithoutCategory,
+        @Param("onlyPendingCategorySuggestions") boolean onlyPendingCategorySuggestions,
+        @Param("pendingStatus") EntryCategorySuggestionStatus pendingStatus,
+        Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"account", "category", "suggestedCategory"})
+    @Query(
+        """
+        select e
+        from Entry e
+        where e.settlementDate between :startDate and :endDate
+          and (:accountId is null or e.account.id = :accountId)
+          and (
+                (:onlyWithoutCategory = true and e.category is null)
+                or (:onlyWithoutCategory = false and (:categoryId is null or e.category.id = :categoryId))
+          )
           and (
                 :descriptionFilter is null
-                or upper(function('translate', e.description, :accentedCharacters, :plainCharacters))
+                or upper(
+                    function(
+                        'translate',
+                        e.description,
+                        'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ',
+                        'AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn'
+                    )
+                )
                     like concat(
                         '%',
                         :descriptionFilter,
@@ -48,8 +81,6 @@ public interface JpaEntryRepository extends JpaRepository<Entry, Long> {
         @Param("onlyWithoutCategory") boolean onlyWithoutCategory,
         @Param("onlyPendingCategorySuggestions") boolean onlyPendingCategorySuggestions,
         @Param("pendingStatus") EntryCategorySuggestionStatus pendingStatus,
-        @Param("accentedCharacters") String accentedCharacters,
-        @Param("plainCharacters") String plainCharacters,
         Pageable pageable
     );
 

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapterTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,8 +39,6 @@ class EntryRepositoryAdapterTest {
             anyBoolean(),
             anyBoolean(),
             any(EntryCategorySuggestionStatus.class),
-            anyString(),
-            anyString(),
             any(Pageable.class)
         )).thenReturn(Page.empty());
 
@@ -65,11 +64,57 @@ class EntryRepositoryAdapterTest {
             anyBoolean(),
             anyBoolean(),
             any(EntryCategorySuggestionStatus.class),
-            anyString(),
-            anyString(),
             any(Pageable.class)
         );
 
         org.assertj.core.api.Assertions.assertThat(descriptionCaptor.getValue()).isEqualTo("CAFE\\_100\\%");
+    }
+
+    @Test
+    void shouldUseQueryWithoutDescriptionWhenFilterIsBlank() {
+        when(jpaEntryRepository.searchBySettlementDateBetweenAndFiltersWithoutDescription(
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyBoolean(),
+            anyBoolean(),
+            any(EntryCategorySuggestionStatus.class),
+            any(Pageable.class)
+        )).thenReturn(Page.empty());
+
+        entryRepositoryAdapter.listMostRecentBySettlementDateBetweenAndFilters(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            1L,
+            2L,
+            "   ",
+            false,
+            false,
+            0,
+            25
+        );
+
+        verify(jpaEntryRepository).searchBySettlementDateBetweenAndFiltersWithoutDescription(
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyBoolean(),
+            anyBoolean(),
+            any(EntryCategorySuggestionStatus.class),
+            any(Pageable.class)
+        );
+        verify(jpaEntryRepository, never()).searchBySettlementDateBetweenAndFilters(
+            any(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyBoolean(),
+            anyBoolean(),
+            any(EntryCategorySuggestionStatus.class),
+            any(Pageable.class)
+        );
     }
 }

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepositoryTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepositoryTest.java
@@ -22,9 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @TestPropertySource(properties = "spring.sql.init.mode=never")
 class JpaEntryRepositoryTest {
 
-    private static final String ACCENTED_CHARACTERS = "ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ";
-    private static final String PLAIN_CHARACTERS = "AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn";
-
     @Autowired
     private JpaEntryRepository jpaEntryRepository;
 
@@ -49,14 +46,38 @@ class JpaEntryRepositoryTest {
             false,
             false,
             EntryCategorySuggestionStatus.PENDING,
-            ACCENTED_CHARACTERS,
-            PLAIN_CHARACTERS,
             PageRequest.of(0, 25)
         );
 
         assertThat(result.getContent())
             .extracting(Entry::getId)
             .containsExactly(matchingEntry.getId());
+    }
+
+    @Test
+    void shouldListEntriesWithoutDescriptionFilter() {
+        Account account = persistAccount("Conta teste");
+        Category category = persistCategory("Categoria teste");
+        Entry newerEntry = persistEntry(account, category, "Compra mercado");
+        Entry olderEntry = persistEntry(account, category, "Padaria");
+        olderEntry.setSettlementDate(LocalDate.of(2026, 1, 5));
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Entry> result = jpaEntryRepository.searchBySettlementDateBetweenAndFiltersWithoutDescription(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            account.getId(),
+            null,
+            false,
+            false,
+            EntryCategorySuggestionStatus.PENDING,
+            PageRequest.of(0, 25)
+        );
+
+        assertThat(result.getContent())
+            .extracting(Entry::getId)
+            .containsExactly(newerEntry.getId(), olderEntry.getId());
     }
 
     private Account persistAccount(String title) {


### PR DESCRIPTION
### Motivation

- Prevent passing blank description filters to the database and avoid unnecessary translation/like work when no meaningful filter is provided.
- Provide a JPQL query variant that omits the description/translate/like clause to simplify generated SQL and avoid passing large mapping parameters.

### Description

- Add `searchBySettlementDateBetweenAndFiltersWithoutDescription` to `JpaEntryRepository` with an optimized JPQL query that omits the description filtering clause and uses `@EntityGraph` for eager associations.
- Update `EntryRepositoryAdapter` to return `null` for blank description filters in `normalizeDescriptionFilter` and to choose between the new no-description query and the existing query based on the normalized value.
- Inline accented-to-plain character mappings into the `searchBySettlementDateBetweenAndFilters` JPQL and remove the now-unused mapping parameters and constants.
- Update tests: `EntryRepositoryAdapterTest` was adjusted to verify normalization and now includes `shouldUseQueryWithoutDescriptionWhenFilterIsBlank`, and `JpaEntryRepositoryTest` was extended with `shouldListEntriesWithoutDescriptionFilter` while removing the previous constants.

### Testing

- Ran unit tests in `EntryRepositoryAdapterTest` including `shouldNormalizeDescriptionFilterBeforeQuerying` and `shouldUseQueryWithoutDescriptionWhenFilterIsBlank`, which passed.
- Ran integration tests in `JpaEntryRepositoryTest` including `shouldFilterByDescriptionIgnoringCaseAndAccents` and `shouldListEntriesWithoutDescriptionFilter`, which passed.
- Ran the test suite for the modified persistence package and all modified tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a05d16688332a3ba57b0cd21a233)