### PR TITLE
Fix custom global date filter navigation

### DIFF
--- a/src/main/java/dev/ccosta/aisha/web/timefilter/DateFilterState.java
+++ b/src/main/java/dev/ccosta/aisha/web/timefilter/DateFilterState.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjusters;
 
 public class DateFilterState implements Serializable {
@@ -33,6 +34,7 @@ public class DateFilterState implements Serializable {
 
     public void goPrevious(Clock clock) {
         if (custom) {
+            shiftCustomRange(-1);
             return;
         }
 
@@ -51,6 +53,7 @@ public class DateFilterState implements Serializable {
 
     public void goNext(Clock clock) {
         if (custom) {
+            shiftCustomRange(1);
             return;
         }
 
@@ -70,6 +73,14 @@ public class DateFilterState implements Serializable {
         this.offset = 0;
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+
+    private void shiftCustomRange(int direction) {
+        long intervalLengthInDays = ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        long shiftInDays = intervalLengthInDays * direction;
+        this.startDate = startDate.plusDays(shiftInDays);
+        this.endDate = endDate.plusDays(shiftInDays);
     }
 
     private void recalculateFromPreset(Clock clock) {

--- a/src/test/java/dev/ccosta/aisha/web/timefilter/DateFilterStateTest.java
+++ b/src/test/java/dev/ccosta/aisha/web/timefilter/DateFilterStateTest.java
@@ -62,6 +62,25 @@ class DateFilterStateTest {
     }
 
     @Test
+    void shouldNavigateCustomIntervalKeepingIntervalLength() {
+        DateFilterState state = DateFilterState.defaultState(FIXED_CLOCK);
+
+        state.applyCustom(LocalDate.of(2026, 1, 10), LocalDate.of(2026, 1, 20));
+
+        state.goPrevious(FIXED_CLOCK);
+        assertThat(state.getStartDate()).isEqualTo(LocalDate.of(2025, 12, 30));
+        assertThat(state.getEndDate()).isEqualTo(LocalDate.of(2026, 1, 9));
+
+        state.goNext(FIXED_CLOCK);
+        assertThat(state.getStartDate()).isEqualTo(LocalDate.of(2026, 1, 10));
+        assertThat(state.getEndDate()).isEqualTo(LocalDate.of(2026, 1, 20));
+
+        state.goNext(FIXED_CLOCK);
+        assertThat(state.getStartDate()).isEqualTo(LocalDate.of(2026, 1, 21));
+        assertThat(state.getEndDate()).isEqualTo(LocalDate.of(2026, 1, 31));
+    }
+
+    @Test
     void shouldRejectInvalidCustomInterval() {
         DateFilterState state = DateFilterState.defaultState(FIXED_CLOCK);
 


### PR DESCRIPTION
### Motivation
- Fix a bug where the global date filter navigation buttons (Previous/Next) did nothing when a custom start/end range was set, so navigation only worked for preset ranges (Week/Month/Year).

### Description
- Update `DateFilterState` so `goPrevious` and `goNext` shift an active custom range by its inclusive length using a new `shiftCustomRange` method, preserving the number of days selected; keep preset behavior unchanged and add a unit test verifying navigation for custom intervals.

### Testing
- Ran `mvn -q -Dtest=DateFilterStateTest test` and `mvn test`, and all tests completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da784af164833292c2bb3583523433)