### PR TITLE
Fix cumulative account balances by period in accounts report

### DIFF
--- a/src/main/java/dev/ccosta/aisha/application/account/AccountBalanceReportService.java
+++ b/src/main/java/dev/ccosta/aisha/application/account/AccountBalanceReportService.java
@@ -72,16 +72,19 @@ public class AccountBalanceReportService {
         List<AccountBalanceRow> rows = new ArrayList<>();
         for (Account account : accounts) {
             Map<LocalDate, BigDecimal> accountBuckets = periodBalancesByAccount.getOrDefault(account.getId(), Map.of());
+            BigDecimal previousPeriodBalance = previousBalancesByAccount.getOrDefault(account.getId(), BigDecimal.ZERO);
             List<BigDecimal> periodBalances = new ArrayList<>(buckets.size());
+            BigDecimal runningBalance = previousPeriodBalance;
             for (AccountBalanceBucket bucket : buckets) {
-                periodBalances.add(accountBuckets.getOrDefault(bucket.startDate(), BigDecimal.ZERO));
+                runningBalance = runningBalance.add(accountBuckets.getOrDefault(bucket.startDate(), BigDecimal.ZERO));
+                periodBalances.add(runningBalance);
             }
 
             rows.add(new AccountBalanceRow(
                 account.getId(),
                 account.getTitle(),
                 account.getDescription(),
-                previousBalancesByAccount.getOrDefault(account.getId(), BigDecimal.ZERO),
+                previousPeriodBalance,
                 periodBalances
             ));
         }

--- a/src/test/java/dev/ccosta/aisha/application/account/AccountBalanceReportServiceTest.java
+++ b/src/test/java/dev/ccosta/aisha/application/account/AccountBalanceReportServiceTest.java
@@ -50,14 +50,15 @@ class AccountBalanceReportServiceTest {
 
         AccountBalanceRow checkingRow = report.rows().get(0);
         assertThat(checkingRow.previousPeriodBalance()).isEqualByComparingTo("150.00");
-        assertThat(checkingRow.periodBalances().get(0)).isEqualByComparingTo("500.00");
-        assertThat(checkingRow.periodBalances().get(1)).isEqualByComparingTo("-120.50");
-        assertThat(checkingRow.periodBalances().get(2)).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(checkingRow.periodBalances().get(0)).isEqualByComparingTo("650.00");
+        assertThat(checkingRow.periodBalances().get(1)).isEqualByComparingTo("529.50");
+        assertThat(checkingRow.periodBalances().get(2)).isEqualByComparingTo("529.50");
 
         AccountBalanceRow cashRow = report.rows().get(1);
         assertThat(cashRow.previousPeriodBalance()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(cashRow.periodBalances().get(0)).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(cashRow.periodBalances().get(1)).isEqualByComparingTo("60.00");
-        assertThat(cashRow.periodBalances().get(10)).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(cashRow.periodBalances().get(10)).isEqualByComparingTo("60.00");
     }
 
     @Test
@@ -83,9 +84,9 @@ class AccountBalanceReportServiceTest {
         assertThat(row.previousPeriodBalance()).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(row.periodBalances()).containsExactly(
             new BigDecimal("250.00"),
-            BigDecimal.ZERO,
-            new BigDecimal("25.00"),
-            BigDecimal.ZERO
+            new BigDecimal("250.00"),
+            new BigDecimal("275.00"),
+            new BigDecimal("275.00")
         );
     }
 


### PR DESCRIPTION
### Motivation
- The balances section in account listing was showing per-period movements only and not the accumulated balance across periods, which is incorrect for a running account balance view. 
- The report must use the opening balance before the selected range as the starting point for accumulation. 
- Keep the opening balance (`previousPeriodBalance`) visible while changing per-period columns to show the running balance.

### Description
- Updated `AccountBalanceReportService` to compute a `runningBalance` initialized with `previousPeriodBalance` and add each bucket's movement into it before adding the value to `periodBalances` (file: `src/main/java/dev/ccosta/aisha/application/account/AccountBalanceReportService.java`).
- Preserved `previousPeriodBalance` as the opening balance in `AccountBalanceRow` while changing the period columns to cumulative values. 
- Adjusted `AccountBalanceReportServiceTest` expectations to validate the running-balance behavior for monthly and daily granularities (file: `src/test/java/dev/ccosta/aisha/application/account/AccountBalanceReportServiceTest.java`).

### Testing
- Ran the focused unit test with `./mvnw -q -Dtest=AccountBalanceReportServiceTest test` and it passed. 
- Ran the full test suite with `./mvnw test` and all tests passed (`Tests run: 146, Failures: 0, Errors: 0`) and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db147af9f0833295f57f57c61561b2)