### PR TITLE
feat(accounts): add account type and dashboard balances by type

### DIFF
--- a/src/main/java/dev/ccosta/aisha/application/account/AccountService.java
+++ b/src/main/java/dev/ccosta/aisha/application/account/AccountService.java
@@ -2,6 +2,7 @@ package dev.ccosta.aisha.application.account;
 
 import dev.ccosta.aisha.domain.account.Account;
 import dev.ccosta.aisha.domain.account.AccountRepository;
+import dev.ccosta.aisha.domain.account.AccountType;
 import dev.ccosta.aisha.domain.entry.EntryRepository;
 import dev.ccosta.aisha.application.entry.EntrySettlementAfterAccountDeactivationException;
 import dev.ccosta.aisha.domain.shared.PagedResult;
@@ -73,6 +74,9 @@ public class AccountService {
     @Transactional
     public Account create(Account account) {
         validateDeactivationDate(account.getDeactivationDate(), null);
+        if (account.getAccountType() == null) {
+            account.setAccountType(AccountType.OTHER);
+        }
         return accountRepository.save(account);
     }
 
@@ -91,6 +95,7 @@ public class AccountService {
                 account.setInitialBalance(null);
                 account.setInitialBalanceDate(null);
                 account.setDeactivationDate(null);
+                account.setAccountType(AccountType.OTHER);
                 return accountRepository.save(account);
             });
     }
@@ -104,6 +109,7 @@ public class AccountService {
         existing.setInitialBalance(updatedData.getInitialBalance());
         existing.setInitialBalanceDate(updatedData.getInitialBalanceDate());
         existing.setDeactivationDate(updatedData.getDeactivationDate());
+        existing.setAccountType(updatedData.getAccountType() == null ? AccountType.OTHER : updatedData.getAccountType());
         return accountRepository.save(existing);
     }
 

--- a/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardAccountTypeBalance.java
+++ b/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardAccountTypeBalance.java
@@ -1,0 +1,13 @@
+package dev.ccosta.aisha.application.dashboard;
+
+import dev.ccosta.aisha.domain.account.AccountType;
+import java.math.BigDecimal;
+
+/**
+ * Represents the current accumulated balance grouped by account type.
+ *
+ * @param accountType account type used for grouping
+ * @param balance current balance for the type at the selected dashboard end date
+ */
+public record DashboardAccountTypeBalance(AccountType accountType, BigDecimal balance) {
+}

--- a/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardService.java
+++ b/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardService.java
@@ -2,6 +2,7 @@ package dev.ccosta.aisha.application.dashboard;
 
 import dev.ccosta.aisha.domain.account.Account;
 import dev.ccosta.aisha.domain.account.AccountRepository;
+import dev.ccosta.aisha.domain.account.AccountType;
 import dev.ccosta.aisha.domain.category.Category;
 import dev.ccosta.aisha.domain.category.CategoryRepository;
 import dev.ccosta.aisha.domain.entry.Entry;
@@ -10,6 +11,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -89,7 +91,8 @@ public class DashboardService {
         return new DashboardSummary(
             metric(currentBalance, previousBalance),
             metric(currentExpenses, previousExpenses),
-            metric(currentRevenues, previousRevenues)
+            metric(currentRevenues, previousRevenues),
+            buildAccountTypeBalances(accounts, entries, endDate)
         );
     }
 
@@ -348,6 +351,52 @@ public class DashboardService {
             buckets,
             series
         );
+    }
+
+
+    private List<DashboardAccountTypeBalance> buildAccountTypeBalances(List<Account> accounts, List<Entry> entries, LocalDate endDate) {
+        Map<Long, BigDecimal> balanceByAccountId = new HashMap<>();
+        Map<Long, AccountType> typeByAccountId = new HashMap<>();
+
+        for (Account account : accounts) {
+            if (account.getId() == null) {
+                continue;
+            }
+            if (account.getInitialBalance() == null || account.getInitialBalanceDate() == null || account.getInitialBalanceDate().isAfter(endDate)) {
+                balanceByAccountId.put(account.getId(), BigDecimal.ZERO);
+            } else {
+                balanceByAccountId.put(account.getId(), account.getInitialBalance());
+            }
+            typeByAccountId.put(account.getId(), account.getAccountType() == null ? AccountType.OTHER : account.getAccountType());
+        }
+
+        for (Entry entry : entries) {
+            if (entry.getAccount() == null || entry.getAccount().getId() == null) {
+                continue;
+            }
+            Long accountId = entry.getAccount().getId();
+            if (!balanceByAccountId.containsKey(accountId)) {
+                continue;
+            }
+            if (entry.getSettlementDate().isAfter(endDate) || mustIgnoreEntryByAccountStartingPoint(entry)) {
+                continue;
+            }
+            balanceByAccountId.merge(accountId, entry.getAmount(), BigDecimal::add);
+        }
+
+        EnumMap<AccountType, BigDecimal> balanceByType = new EnumMap<>(AccountType.class);
+        for (AccountType accountType : AccountType.values()) {
+            balanceByType.put(accountType, BigDecimal.ZERO);
+        }
+
+        for (Map.Entry<Long, BigDecimal> entry : balanceByAccountId.entrySet()) {
+            AccountType accountType = typeByAccountId.getOrDefault(entry.getKey(), AccountType.OTHER);
+            balanceByType.merge(accountType, entry.getValue(), BigDecimal::add);
+        }
+
+        return java.util.Arrays.stream(AccountType.values())
+            .map(accountType -> new DashboardAccountTypeBalance(accountType, balanceByType.getOrDefault(accountType, BigDecimal.ZERO)))
+            .toList();
     }
 
     private DashboardMetric metric(BigDecimal currentValue, BigDecimal previousValue) {

--- a/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardSummary.java
+++ b/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardSummary.java
@@ -1,4 +1,11 @@
 package dev.ccosta.aisha.application.dashboard;
 
-public record DashboardSummary(DashboardMetric currentBalance, DashboardMetric totalExpenses, DashboardMetric totalRevenues) {
+import java.util.List;
+
+public record DashboardSummary(
+    DashboardMetric currentBalance,
+    DashboardMetric totalExpenses,
+    DashboardMetric totalRevenues,
+    List<DashboardAccountTypeBalance> accountTypeBalances
+) {
 }

--- a/src/main/java/dev/ccosta/aisha/domain/account/Account.java
+++ b/src/main/java/dev/ccosta/aisha/domain/account/Account.java
@@ -2,6 +2,8 @@ package dev.ccosta.aisha.domain.account;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,6 +33,10 @@ public class Account {
 
     @Column(name = "deactivation_date")
     private LocalDate deactivationDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_type", nullable = false, length = 30)
+    private AccountType accountType = AccountType.OTHER;
 
     public Long getId() {
         return id;
@@ -66,6 +72,14 @@ public class Account {
 
     public void setInitialBalanceDate(LocalDate initialBalanceDate) {
         this.initialBalanceDate = initialBalanceDate;
+    }
+
+    public AccountType getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(AccountType accountType) {
+        this.accountType = accountType;
     }
 
     public LocalDate getDeactivationDate() {

--- a/src/main/java/dev/ccosta/aisha/domain/account/AccountType.java
+++ b/src/main/java/dev/ccosta/aisha/domain/account/AccountType.java
@@ -1,0 +1,12 @@
+package dev.ccosta.aisha.domain.account;
+
+/**
+ * Enumerates supported account types used for categorization and dashboard grouping.
+ */
+public enum AccountType {
+    CHECKING,
+    CREDIT,
+    INVESTMENT,
+    FOOD,
+    OTHER
+}

--- a/src/main/java/dev/ccosta/aisha/web/account/AccountController.java
+++ b/src/main/java/dev/ccosta/aisha/web/account/AccountController.java
@@ -6,6 +6,7 @@ import dev.ccosta.aisha.application.account.AccountNotFoundException;
 import dev.ccosta.aisha.application.account.AccountBalanceReportService;
 import dev.ccosta.aisha.application.account.AccountService;
 import dev.ccosta.aisha.domain.account.Account;
+import dev.ccosta.aisha.domain.account.AccountType;
 import dev.ccosta.aisha.domain.shared.PagedResult;
 import dev.ccosta.aisha.infrastructure.logging.CorrelationIdFilter;
 import dev.ccosta.aisha.web.navigation.ReturnPathSupport;
@@ -68,6 +69,7 @@ public class AccountController {
     @GetMapping("/new")
     public String createForm(@RequestParam(name = "returnTo", required = false) String returnTo, Model model) {
         model.addAttribute("form", new AccountForm());
+        model.addAttribute("accountTypes", AccountType.values());
         model.addAttribute("mode", "create");
         model.addAttribute("returnTo", ReturnPathSupport.resolveReturnPath(returnTo, "/accounts"));
         return "accounts/form";
@@ -82,6 +84,7 @@ public class AccountController {
     ) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("mode", "create");
+            model.addAttribute("accountTypes", AccountType.values());
             model.addAttribute("returnTo", ReturnPathSupport.resolveReturnPath(returnTo, "/accounts"));
             return "accounts/form";
         }
@@ -96,6 +99,7 @@ public class AccountController {
                 null
             );
             model.addAttribute("mode", "create");
+            model.addAttribute("accountTypes", AccountType.values());
             model.addAttribute("returnTo", ReturnPathSupport.resolveReturnPath(returnTo, "/accounts"));
             return "accounts/form";
         }
@@ -111,6 +115,7 @@ public class AccountController {
         Account account = accountService.findById(id);
         model.addAttribute("form", fromDomain(account));
         model.addAttribute("accountId", id);
+        model.addAttribute("accountTypes", AccountType.values());
         model.addAttribute("mode", "edit");
         model.addAttribute("returnTo", ReturnPathSupport.resolveReturnPath(returnTo, "/accounts"));
         return "accounts/form";
@@ -126,6 +131,7 @@ public class AccountController {
     ) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("accountId", id);
+            model.addAttribute("accountTypes", AccountType.values());
             model.addAttribute("mode", "edit");
             model.addAttribute("returnTo", ReturnPathSupport.resolveReturnPath(returnTo, "/accounts"));
             return "accounts/form";
@@ -141,6 +147,7 @@ public class AccountController {
                 null
             );
             model.addAttribute("accountId", id);
+            model.addAttribute("accountTypes", AccountType.values());
             model.addAttribute("mode", "edit");
             model.addAttribute("returnTo", ReturnPathSupport.resolveReturnPath(returnTo, "/accounts"));
             return "accounts/form";
@@ -264,6 +271,7 @@ public class AccountController {
         account.setInitialBalance(form.getInitialBalance());
         account.setInitialBalanceDate(form.getInitialBalanceDate());
         account.setDeactivationDate(form.getDeactivationDate());
+        account.setAccountType(form.getAccountType());
         return account;
     }
 
@@ -274,6 +282,7 @@ public class AccountController {
         form.setInitialBalance(account.getInitialBalance());
         form.setInitialBalanceDate(account.getInitialBalanceDate());
         form.setDeactivationDate(account.getDeactivationDate());
+        form.setAccountType(account.getAccountType());
         return form;
     }
 }

--- a/src/main/java/dev/ccosta/aisha/web/account/AccountForm.java
+++ b/src/main/java/dev/ccosta/aisha/web/account/AccountForm.java
@@ -1,5 +1,6 @@
 package dev.ccosta.aisha.web.account;
 
+import dev.ccosta.aisha.domain.account.AccountType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
@@ -27,6 +28,9 @@ public class AccountForm {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate deactivationDate;
+
+    @NotNull(message = "{accountForm.accountType.notNull}")
+    private AccountType accountType = AccountType.OTHER;
 
     public String getTitle() {
         return title;
@@ -58,6 +62,14 @@ public class AccountForm {
 
     public void setInitialBalanceDate(LocalDate initialBalanceDate) {
         this.initialBalanceDate = initialBalanceDate;
+    }
+
+    public AccountType getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(AccountType accountType) {
+        this.accountType = accountType;
     }
 
     public LocalDate getDeactivationDate() {

--- a/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardApiController.java
+++ b/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardApiController.java
@@ -1,5 +1,6 @@
 package dev.ccosta.aisha.web.dashboard.api;
 
+import dev.ccosta.aisha.application.dashboard.DashboardAccountTypeBalance;
 import dev.ccosta.aisha.application.dashboard.DashboardBalanceEvolution;
 import dev.ccosta.aisha.application.dashboard.DashboardBalancePoint;
 import dev.ccosta.aisha.application.dashboard.DashboardCategoryTotalsEvolution;
@@ -40,7 +41,8 @@ public class DashboardApiController {
         return new DashboardSummaryResponse(
             toMetric(summary.currentBalance()),
             toMetric(summary.totalExpenses()),
-            toMetric(summary.totalRevenues())
+            toMetric(summary.totalRevenues()),
+            summary.accountTypeBalances().stream().map(this::toAccountTypeBalance).toList()
         );
     }
 
@@ -146,6 +148,10 @@ public class DashboardApiController {
             metric.previousValue(),
             metric.variationPercent()
         );
+    }
+
+    private DashboardSummaryResponse.DashboardAccountTypeBalanceResponse toAccountTypeBalance(DashboardAccountTypeBalance item) {
+        return new DashboardSummaryResponse.DashboardAccountTypeBalanceResponse(item.accountType(), item.balance());
     }
 
     private DashboardBalanceEvolutionResponse.DashboardBalancePointResponse toPoint(DashboardBalancePoint point) {

--- a/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardSummaryResponse.java
+++ b/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardSummaryResponse.java
@@ -1,12 +1,18 @@
 package dev.ccosta.aisha.web.dashboard.api;
 
+import dev.ccosta.aisha.domain.account.AccountType;
 import java.math.BigDecimal;
+import java.util.List;
 
 public record DashboardSummaryResponse(
     DashboardMetricResponse currentBalance,
     DashboardMetricResponse totalExpenses,
-    DashboardMetricResponse totalRevenues
+    DashboardMetricResponse totalRevenues,
+    List<DashboardAccountTypeBalanceResponse> accountTypeBalances
 ) {
     public record DashboardMetricResponse(BigDecimal currentValue, BigDecimal previousValue, BigDecimal variationPercent) {
+    }
+
+    public record DashboardAccountTypeBalanceResponse(AccountType accountType, BigDecimal balance) {
     }
 }

--- a/src/main/resources/db/migration/V10__accounts_add_account_type.sql
+++ b/src/main/resources/db/migration/V10__accounts_add_account_type.sql
@@ -1,0 +1,9 @@
+ALTER TABLE accounts
+    ADD COLUMN account_type VARCHAR(30) DEFAULT 'OTHER';
+
+UPDATE accounts
+SET account_type = 'OTHER'
+WHERE account_type IS NULL;
+
+ALTER TABLE accounts
+    ALTER COLUMN account_type SET NOT NULL;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -309,6 +309,7 @@ accounts.form.title.edit=Editar conta
 accounts.form.field.title=Título
 accounts.form.field.title.required=Título *
 accounts.form.field.description=Descrição
+accounts.form.field.accountType.required=Tipo de conta *
 accounts.form.field.initialBalance=Saldo inicial
 accounts.form.field.initialBalance.required=Saldo inicial *
 accounts.form.field.initialBalanceDate=Data do saldo inicial
@@ -332,6 +333,7 @@ accounts.list.table.select=Selecionar
 accounts.list.table.selectItem=Selecionar conta
 accounts.list.table.title=Título
 accounts.list.table.description=Descrição
+accounts.list.table.accountType=Tipo
 accounts.list.table.deactivationDate=Desativação
 accounts.list.table.actions=Ações
 accounts.list.empty=Nenhuma conta cadastrada.
@@ -396,6 +398,7 @@ accountForm.description.size=Descrição deve ter no máximo 300 caracteres
 accountForm.initialBalance.notNull=Saldo inicial é obrigatório
 accountForm.initialBalance.digits=Saldo inicial deve ter até 2 casas decimais
 accountForm.initialBalanceDate.notNull=Data do saldo inicial é obrigatória
+accountForm.accountType.notNull=Tipo de conta é obrigatório
 accountForm.deactivationDate.invalid=Data da desativação não pode ser anterior à data de liquidação mais recente ({0}).
 
 entryForm.settlementDate.afterAccountDeactivation=Data de liquidação não pode ser posterior à data de desativação da conta ({0}).
@@ -522,3 +525,13 @@ footer.link.github=Github
 
 entries.form.registrationInfo.manual=Entry registered manually on {0}.
 entries.form.registrationInfo.import=Entry registered by import on {0}.
+
+account.type.checking=Corrente
+account.type.credit=Crédito
+account.type.investment=Investimento
+account.type.food=Alimentação
+account.type.other=Outros
+
+dashboard.accountTypeBalances.title=Saldos por tipo de conta
+dashboard.accountTypeBalances.error=Não foi possível carregar os saldos por tipo de conta.
+dashboard.accountTypeBalances.empty=Sem contas para exibir saldos por tipo.

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -314,6 +314,7 @@ accounts.form.title.edit=Editar conta
 accounts.form.field.title=Título
 accounts.form.field.title.required=Título *
 accounts.form.field.description=Descrição
+accounts.form.field.accountType.required=Tipo de conta *
 accounts.form.field.initialBalance=Saldo inicial
 accounts.form.field.initialBalance.required=Saldo inicial *
 accounts.form.field.initialBalanceDate=Data do saldo inicial
@@ -337,6 +338,7 @@ accounts.list.table.select=Selecionar
 accounts.list.table.selectItem=Selecionar conta
 accounts.list.table.title=Título
 accounts.list.table.description=Descrição
+accounts.list.table.accountType=Tipo
 accounts.list.table.deactivationDate=Desativação
 accounts.list.table.actions=Ações
 accounts.list.empty=Nenhuma conta cadastrada.
@@ -401,6 +403,7 @@ accountForm.description.size=Descrição deve ter no máximo 300 caracteres
 accountForm.initialBalance.notNull=Saldo inicial é obrigatório
 accountForm.initialBalance.digits=Saldo inicial deve ter até 2 casas decimais
 accountForm.initialBalanceDate.notNull=Data do saldo inicial é obrigatória
+accountForm.accountType.notNull=Tipo de conta é obrigatório
 accountForm.deactivationDate.invalid=Data da desativação não pode ser anterior à data de liquidação mais recente ({0}).
 
 entryForm.settlementDate.afterAccountDeactivation=Data de liquidação não pode ser posterior à data de desativação da conta ({0}).
@@ -520,3 +523,13 @@ footer.link.privacyPolicy=Política de Privacidade
 footer.link.termsOfUse=Termos de Uso
 footer.projectLinks.title=Links do projeto
 footer.link.github=Github
+
+account.type.checking=Corrente
+account.type.credit=Crédito
+account.type.investment=Investimento
+account.type.food=Alimentação
+account.type.other=Outros
+
+dashboard.accountTypeBalances.title=Saldos por tipo de conta
+dashboard.accountTypeBalances.error=Não foi possível carregar os saldos por tipo de conta.
+dashboard.accountTypeBalances.empty=Sem contas para exibir saldos por tipo.

--- a/src/main/resources/templates/accounts/form.html
+++ b/src/main/resources/templates/accounts/form.html
@@ -29,6 +29,14 @@
                 <p class="error" th:if="${#fields.hasErrors('description')}" th:errors="*{description}"></p>
             </div>
 
+            <div class="field">
+                <label for="accountType" th:text="#{accounts.form.field.accountType.required}"></label>
+                <select id="accountType" th:field="*{accountType}" required>
+                    <option th:each="accountType : ${accountTypes}" th:value="${accountType}" th:text="#{${'account.type.' + accountType.name().toLowerCase()}}"></option>
+                </select>
+                <p class="error" th:if="${#fields.hasErrors('accountType')}" th:errors="*{accountType}"></p>
+            </div>
+
             <div class="grid-2">
                 <div class="field">
                     <label for="initialBalance" th:text="#{accounts.form.field.initialBalance.required}"></label>

--- a/src/main/resources/templates/accounts/list.html
+++ b/src/main/resources/templates/accounts/list.html
@@ -145,6 +145,12 @@
                         </th>
                         <th>
                             <span class="table-heading-label">
+                                <i data-lucide="badge-check" aria-hidden="true"></i>
+                                <span th:text="#{accounts.list.table.accountType}"></span>
+                            </span>
+                        </th>
+                        <th>
+                            <span class="table-heading-label">
                                 <i data-lucide="calendar-x-2" aria-hidden="true"></i>
                                 <span th:text="#{accounts.list.table.deactivationDate}"></span>
                             </span>
@@ -159,7 +165,7 @@
                     </thead>
                     <tbody>
                     <tr th:if="${#lists.isEmpty(accounts)}" class="empty-row">
-                        <td colspan="5" class="empty" th:text="#{accounts.list.empty}"></td>
+                        <td colspan="6" class="empty" th:text="#{accounts.list.empty}"></td>
                     </tr>
                     <tr th:each="account : ${accounts}">
                         <td class="cell-select" th:attr="data-label=#{accounts.list.table.select}">
@@ -167,6 +173,7 @@
                         </td>
                         <td th:attr="data-label=#{accounts.list.table.title}" th:text="${account.title}"></td>
                         <td th:attr="data-label=#{accounts.list.table.description}" th:text="${account.description}"></td>
+                        <td th:attr="data-label=#{accounts.list.table.accountType}" th:text="#{${'account.type.' + (account.accountType != null ? account.accountType.name().toLowerCase() : 'other')}}"></td>
                         <td
                             th:attr="data-label=#{accounts.list.table.deactivationDate}"
                             th:text="${account.deactivationDate != null ? #temporals.format(account.deactivationDate, 'dd/MM/yyyy') : '-'}">

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -47,6 +47,40 @@
         </article>
     </section>
 
+    <section class="card chart-card loading" id="account-type-balances-card">
+        <div class="chart-card-head">
+            <div>
+                <h2 th:text="#{dashboard.accountTypeBalances.title}"></h2>
+            </div>
+        </div>
+        <div class="table-wrap">
+            <table class="balances-table">
+                <thead>
+                <tr>
+                    <th>
+                        <span class="table-heading-label">
+                            <i data-lucide="badge-check" aria-hidden="true"></i>
+                            <span th:text="#{accounts.list.table.accountType}"></span>
+                        </span>
+                    </th>
+                    <th class="amount-cell">
+                        <span class="table-heading-label">
+                            <i data-lucide="wallet" aria-hidden="true"></i>
+                            <span th:text="#{dashboard.card.currentBalance}"></span>
+                        </span>
+                    </th>
+                </tr>
+                </thead>
+                <tbody id="account-type-balances-body">
+                <tr>
+                    <td colspan="2" th:text="#{dashboard.loading}"></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+
     <section class="card chart-card loading" id="balance-chart-card">
         <div class="chart-card-head">
             <div>
@@ -134,6 +168,8 @@
         chartSeriesPeriod: /*[[#{dashboard.chart.series.period}]]*/ "Movimentação no período",
         chartLoadError: /*[[#{dashboard.chart.error}]]*/ "Não foi possível carregar o gráfico.",
         summaryLoadError: /*[[#{dashboard.summary.error}]]*/ "Não foi possível carregar este indicador.",
+        accountTypeBalancesLoadError: /*[[#{dashboard.accountTypeBalances.error}]]*/ "Não foi possível carregar os saldos por tipo de conta.",
+        accountTypeBalancesEmpty: /*[[#{dashboard.accountTypeBalances.empty}]]*/ "Sem contas para exibir saldos por tipo.",
         revenueExpenseChartSeriesRevenue: /*[[#{dashboard.revenueExpenseChart.series.revenues}]]*/ "Receitas",
         revenueExpenseChartSeriesExpense: /*[[#{dashboard.revenueExpenseChart.series.expenses}]]*/ "Despesas",
         revenueExpenseChartLoadError: /*[[#{dashboard.revenueExpenseChart.error}]]*/ "Não foi possível carregar o gráfico de receitas vs despesas.",
@@ -145,7 +181,12 @@
         categoryTotalsChartEmpty: /*[[#{dashboard.categoryTotalsChart.empty}]]*/ "Sem dados no período",
         categoryTotalsChartLevelRoot: /*[[#{dashboard.categoryTotalsChart.level.root}]]*/ "Nível: categorias raiz",
         categoryTotalsChartLevelChild: /*[[#{dashboard.categoryTotalsChart.level.child}]]*/ "Nível: subcategorias de {0}",
-        chartMetaRange: /*[[#{dashboard.chart.metaRange}]]*/ "Período: {0} até {1}"
+        chartMetaRange: /*[[#{dashboard.chart.metaRange}]]*/ "Período: {0} até {1}",
+        accountTypeChecking: /*[[#{account.type.checking}]]*/ "Corrente",
+        accountTypeCredit: /*[[#{account.type.credit}]]*/ "Crédito",
+        accountTypeInvestment: /*[[#{account.type.investment}]]*/ "Investimento",
+        accountTypeFood: /*[[#{account.type.food}]]*/ "Alimentação",
+        accountTypeOther: /*[[#{account.type.other}]]*/ "Outros"
     };
 
     const BRL_FORMATTER = new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" });
@@ -194,6 +235,39 @@
             grid: getThemeColor("--color-border-default", "#d7e0e8"),
             surface: getThemeColor("--color-bg-card", "#ffffff")
         };
+    }
+
+    function accountTypeLabel(accountType) {
+        const key = (accountType || "OTHER").toUpperCase();
+        switch (key) {
+            case "CHECKING": return i18n.accountTypeChecking;
+            case "CREDIT": return i18n.accountTypeCredit;
+            case "INVESTMENT": return i18n.accountTypeInvestment;
+            case "FOOD": return i18n.accountTypeFood;
+            default: return i18n.accountTypeOther;
+        }
+    }
+
+    function renderAccountTypeBalances(items) {
+        const card = document.getElementById("account-type-balances-card");
+        const tbody = document.getElementById("account-type-balances-body");
+        if (!card || !tbody) {
+            return;
+        }
+
+        card.classList.remove("loading");
+        tbody.innerHTML = "";
+        const rows = Array.isArray(items) ? items : [];
+        if (rows.length === 0) {
+            tbody.innerHTML = `<tr><td colspan="2">${i18n.accountTypeBalancesEmpty || i18n.loading}</td></tr>`;
+            return;
+        }
+
+        rows.forEach((item) => {
+            const tr = document.createElement("tr");
+            tr.innerHTML = `<td><strong>${accountTypeLabel(item.accountType)}</strong></td><td class="amount-cell">${formatCurrency(item.balance)}</td>`;
+            tbody.appendChild(tr);
+        });
     }
 
     function renderMetric(cardId, metric) {
@@ -248,7 +322,14 @@
             renderMetric("summary-current-balance", data.currentBalance);
             renderMetric("summary-total-expenses", data.totalExpenses);
             renderMetric("summary-total-revenues", data.totalRevenues);
+            renderAccountTypeBalances(data.accountTypeBalances);
         } catch (error) {
+            const balancesBody = document.getElementById("account-type-balances-body");
+            const balancesCard = document.getElementById("account-type-balances-card");
+            if (balancesBody && balancesCard) {
+                balancesCard.classList.remove("loading");
+                balancesBody.innerHTML = `<tr><td colspan="2">${i18n.accountTypeBalancesLoadError}</td></tr>`;
+            }
             cards.forEach((card) => {
                 if (!card) {
                     return;

--- a/src/test/java/dev/ccosta/aisha/application/dashboard/DashboardServiceTest.java
+++ b/src/test/java/dev/ccosta/aisha/application/dashboard/DashboardServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import dev.ccosta.aisha.domain.account.Account;
 import dev.ccosta.aisha.domain.account.AccountRepository;
+import dev.ccosta.aisha.domain.account.AccountType;
 import dev.ccosta.aisha.domain.category.Category;
 import dev.ccosta.aisha.domain.category.CategoryRepository;
 import dev.ccosta.aisha.domain.entry.Entry;
@@ -73,6 +74,35 @@ class DashboardServiceTest {
 
         assertThat(summary.totalRevenues().variationPercent()).isNull();
         assertThat(summary.totalExpenses().variationPercent()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+
+    @Test
+    void shouldBuildAccountTypeBalancesInSummary() {
+        Account checking = newAccount("Conta Corrente", "100.00", LocalDate.of(2026, 1, 1));
+        setId(checking, 1L, Account.class);
+        checking.setAccountType(AccountType.CHECKING);
+
+        Account credit = newAccount("Cartão", "-50.00", LocalDate.of(2026, 1, 1));
+        setId(credit, 2L, Account.class);
+        credit.setAccountType(AccountType.CREDIT);
+
+        when(accountRepository.findAllOrdered()).thenReturn(List.of(checking, credit));
+
+        Entry checkingEntry = newEntry(LocalDate.of(2026, 1, 10), "25.00");
+        checkingEntry.setAccount(checking);
+        Entry creditEntry = newEntry(LocalDate.of(2026, 1, 10), "-10.00");
+        creditEntry.setAccount(credit);
+
+        when(entryRepository.listAllBySettlementDateLessThanEqual(LocalDate.of(2026, 1, 31))).thenReturn(List.of(checkingEntry, creditEntry));
+
+        DashboardSummary summary = dashboardService.buildSummary(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31));
+
+        assertThat(summary.accountTypeBalances()).extracting(item -> item.accountType().name())
+            .containsExactly("CHECKING", "CREDIT", "INVESTMENT", "FOOD", "OTHER");
+        assertThat(summary.accountTypeBalances().get(0).balance()).isEqualByComparingTo("125.00");
+        assertThat(summary.accountTypeBalances().get(1).balance()).isEqualByComparingTo("-60.00");
+        assertThat(summary.accountTypeBalances().get(4).balance()).isEqualByComparingTo("0.00");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Add an account classification to support future behavior differences and allow users to tag accounts by type (Corrente, Crédito, Investimento, Alimentação, Outros). 
- Surface aggregated balances by account type in the dashboard so the UI can show per-type totals without changing existing accounting semantics.

### Description
- Introduced `AccountType` enum and persisted `account_type` (STRING) on `accounts` with Flyway migration `V10` that sets existing rows to `OTHER` and makes the column NOT NULL. 
- Extended domain, service and web layers so account create/edit flows include `accountType` with server-side fallback to `OTHER` when not provided. 
- Updated account templates and list view to show and select the type, and added i18n keys (pt-BR) for labels and enum names. 
- Extended dashboard backend (`DashboardService`) and API response to compute and return `accountTypeBalances`, added a UI card and client-side rendering to display balances per account type, and added a unit test covering aggregation logic.

### Testing
- Ran the full automated test suite with `./mvnw test`, which completed successfully (166 tests, 0 failures, 0 errors, 0 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6318fed308332ac71008e52f8b969)