### PR TITLE
Dashboard: add chart icons, account-type drill-down and simplify chart metadata

### DIFF
--- a/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardAccountBalance.java
+++ b/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardAccountBalance.java
@@ -1,0 +1,15 @@
+package dev.ccosta.aisha.application.dashboard;
+
+import dev.ccosta.aisha.domain.account.AccountType;
+import java.math.BigDecimal;
+
+/**
+ * Represents the current accumulated balance for a specific account at the selected dashboard end date.
+ *
+ * @param accountId account identifier
+ * @param accountTitle account title shown to users
+ * @param accountType account type used by dashboard drill-down interactions
+ * @param balance current balance for the account
+ */
+public record DashboardAccountBalance(Long accountId, String accountTitle, AccountType accountType, BigDecimal balance) {
+}

--- a/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardService.java
+++ b/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardService.java
@@ -92,7 +92,8 @@ public class DashboardService {
             metric(currentBalance, previousBalance),
             metric(currentExpenses, previousExpenses),
             metric(currentRevenues, previousRevenues),
-            buildAccountTypeBalances(accounts, entries, endDate)
+            buildAccountTypeBalances(accounts, entries, endDate),
+            buildAccountBalances(accounts, entries, endDate)
         );
     }
 
@@ -415,6 +416,46 @@ public class DashboardService {
 
         return java.util.Arrays.stream(AccountType.values())
             .map(accountType -> new DashboardAccountTypeBalance(accountType, balanceByType.getOrDefault(accountType, BigDecimal.ZERO)))
+            .toList();
+    }
+
+    private List<DashboardAccountBalance> buildAccountBalances(List<Account> accounts, List<Entry> entries, LocalDate endDate) {
+        Map<Long, BigDecimal> balanceByAccountId = new HashMap<>();
+
+        for (Account account : accounts) {
+            if (account.getId() == null) {
+                continue;
+            }
+
+            if (account.getInitialBalance() == null || account.getInitialBalanceDate() == null || account.getInitialBalanceDate().isAfter(endDate)) {
+                balanceByAccountId.put(account.getId(), BigDecimal.ZERO);
+            } else {
+                balanceByAccountId.put(account.getId(), account.getInitialBalance());
+            }
+        }
+
+        for (Entry entry : entries) {
+            if (entry.getAccount() == null || entry.getAccount().getId() == null) {
+                continue;
+            }
+            Long accountId = entry.getAccount().getId();
+            if (!balanceByAccountId.containsKey(accountId)) {
+                continue;
+            }
+            if (entry.getSettlementDate().isAfter(endDate) || mustIgnoreEntryByAccountStartingPoint(entry)) {
+                continue;
+            }
+            balanceByAccountId.merge(accountId, entry.getAmount(), BigDecimal::add);
+        }
+
+        return accounts.stream()
+            .filter(account -> account.getId() != null)
+            .map(account -> new DashboardAccountBalance(
+                account.getId(),
+                account.getTitle(),
+                account.getAccountType() == null ? AccountType.OTHER : account.getAccountType(),
+                balanceByAccountId.getOrDefault(account.getId(), BigDecimal.ZERO)
+            ))
             .toList();
     }
 

--- a/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardSummary.java
+++ b/src/main/java/dev/ccosta/aisha/application/dashboard/DashboardSummary.java
@@ -6,6 +6,7 @@ public record DashboardSummary(
     DashboardMetric currentBalance,
     DashboardMetric totalExpenses,
     DashboardMetric totalRevenues,
-    List<DashboardAccountTypeBalance> accountTypeBalances
+    List<DashboardAccountTypeBalance> accountTypeBalances,
+    List<DashboardAccountBalance> accountBalances
 ) {
 }

--- a/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardApiController.java
+++ b/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardApiController.java
@@ -1,6 +1,7 @@
 package dev.ccosta.aisha.web.dashboard.api;
 
 import dev.ccosta.aisha.application.dashboard.DashboardAccountTypeBalance;
+import dev.ccosta.aisha.application.dashboard.DashboardAccountBalance;
 import dev.ccosta.aisha.application.dashboard.DashboardBalanceEvolution;
 import dev.ccosta.aisha.application.dashboard.DashboardBalancePoint;
 import dev.ccosta.aisha.application.dashboard.DashboardCategoryTotalsEvolution;
@@ -42,7 +43,8 @@ public class DashboardApiController {
             toMetric(summary.currentBalance()),
             toMetric(summary.totalExpenses()),
             toMetric(summary.totalRevenues()),
-            summary.accountTypeBalances().stream().map(this::toAccountTypeBalance).toList()
+            summary.accountTypeBalances().stream().map(this::toAccountTypeBalance).toList(),
+            summary.accountBalances().stream().map(this::toAccountBalance).toList()
         );
     }
 
@@ -179,6 +181,15 @@ public class DashboardApiController {
 
     private DashboardSummaryResponse.DashboardAccountTypeBalanceResponse toAccountTypeBalance(DashboardAccountTypeBalance item) {
         return new DashboardSummaryResponse.DashboardAccountTypeBalanceResponse(item.accountType(), item.balance());
+    }
+
+    private DashboardSummaryResponse.DashboardAccountBalanceResponse toAccountBalance(DashboardAccountBalance item) {
+        return new DashboardSummaryResponse.DashboardAccountBalanceResponse(
+            item.accountId(),
+            item.accountTitle(),
+            item.accountType(),
+            item.balance()
+        );
     }
 
     private DashboardBalanceEvolutionResponse.DashboardBalancePointResponse toPoint(DashboardBalancePoint point) {

--- a/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardSummaryResponse.java
+++ b/src/main/java/dev/ccosta/aisha/web/dashboard/api/DashboardSummaryResponse.java
@@ -8,11 +8,20 @@ public record DashboardSummaryResponse(
     DashboardMetricResponse currentBalance,
     DashboardMetricResponse totalExpenses,
     DashboardMetricResponse totalRevenues,
-    List<DashboardAccountTypeBalanceResponse> accountTypeBalances
+    List<DashboardAccountTypeBalanceResponse> accountTypeBalances,
+    List<DashboardAccountBalanceResponse> accountBalances
 ) {
     public record DashboardMetricResponse(BigDecimal currentValue, BigDecimal previousValue, BigDecimal variationPercent) {
     }
 
     public record DashboardAccountTypeBalanceResponse(AccountType accountType, BigDecimal balance) {
+    }
+
+    public record DashboardAccountBalanceResponse(
+        Long accountId,
+        String accountTitle,
+        AccountType accountType,
+        BigDecimal balance
+    ) {
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -45,6 +45,7 @@ dashboard.chart.mode.accumulated=Saldo acumulado
 dashboard.chart.mode.period=Sem acumular
 dashboard.chart.granularity.day=diário
 dashboard.chart.granularity.month=mensal
+dashboard.chart.metaGranularity=Granularidade: {0}
 dashboard.chart.meta=Período: {0} até {1} ({2})
 dashboard.chart.series.accumulated=Saldo acumulado
 dashboard.chart.series.period=Movimentação no período
@@ -540,5 +541,8 @@ account.type.food=Alimentação
 account.type.other=Outros
 
 dashboard.accountTypeBalances.title=Saldos por tipo de conta
+dashboard.accountTypeBalances.drillUp=Voltar nível
+dashboard.accountTypeBalances.level.root=Nível: tipos de conta
+dashboard.accountTypeBalances.level.child=Nível: contas do tipo {0}
 dashboard.accountTypeBalances.error=Não foi possível carregar os saldos por tipo de conta.
 dashboard.accountTypeBalances.empty=Sem contas para exibir saldos por tipo.

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -45,6 +45,7 @@ dashboard.chart.mode.accumulated=Saldo acumulado
 dashboard.chart.mode.period=Sem acumular
 dashboard.chart.granularity.day=diário
 dashboard.chart.granularity.month=mensal
+dashboard.chart.metaGranularity=Granularidade: {0}
 dashboard.chart.meta=Período: {0} até {1} ({2})
 dashboard.chart.series.accumulated=Saldo acumulado
 dashboard.chart.series.period=Movimentação no período
@@ -538,5 +539,8 @@ account.type.food=Alimentação
 account.type.other=Outros
 
 dashboard.accountTypeBalances.title=Saldos por tipo de conta
+dashboard.accountTypeBalances.drillUp=Voltar nível
+dashboard.accountTypeBalances.level.root=Nível: tipos de conta
+dashboard.accountTypeBalances.level.child=Nível: contas do tipo {0}
 dashboard.accountTypeBalances.error=Não foi possível carregar os saldos por tipo de conta.
 dashboard.accountTypeBalances.empty=Sem contas para exibir saldos por tipo.

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -1387,6 +1387,17 @@ html[data-theme="dark"] .summary-card-revenue .summary-icon {
   flex-wrap: wrap;
 }
 
+.chart-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chart-title .lucide {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
 .chart-mode-selector {
   display: inline-flex;
   gap: 0.45rem;

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -51,8 +51,15 @@
         <article class="card chart-card loading" id="account-type-balances-card">
             <div class="chart-card-head">
                 <div>
-                    <h2 th:text="#{dashboard.accountTypeBalances.title}"></h2>
+                    <h2 class="chart-title">
+                        <i data-lucide="wallet-cards" aria-hidden="true"></i>
+                        <span th:text="#{dashboard.accountTypeBalances.title}"></span>
+                    </h2>
                 </div>
+                <button class="btn btn-secondary" id="account-type-balances-drill-up" type="button" disabled>
+                    <i data-lucide="arrow-up" aria-hidden="true"></i>
+                    <span th:text="#{dashboard.accountTypeBalances.drillUp}"></span>
+                </button>
             </div>
             <p class="chart-meta" id="account-type-balances-meta" th:text="#{dashboard.loading}"></p>
             <div class="chart-wrap chart-wrap-donut">
@@ -63,7 +70,10 @@
         <article class="card chart-card loading" id="balance-chart-card">
             <div class="chart-card-head">
                 <div>
-                    <h2 th:text="#{dashboard.chart.title}"></h2>
+                    <h2 class="chart-title">
+                        <i data-lucide="line-chart" aria-hidden="true"></i>
+                        <span th:text="#{dashboard.chart.title}"></span>
+                    </h2>
                     <p th:text="#{dashboard.chart.subtitle}"></p>
                 </div>
                 <div class="chart-mode-selector" role="group" th:attr="aria-label=#{dashboard.chart.mode.aria}">
@@ -87,7 +97,10 @@
     <section class="card chart-card loading" id="revenues-expenses-chart-card">
         <div class="chart-card-head">
             <div>
-                <h2 th:text="#{dashboard.revenueExpenseChart.title}"></h2>
+                <h2 class="chart-title">
+                    <i data-lucide="bar-chart-3" aria-hidden="true"></i>
+                    <span th:text="#{dashboard.revenueExpenseChart.title}"></span>
+                </h2>
                 <p th:text="#{dashboard.revenueExpenseChart.subtitle}"></p>
             </div>
         </div>
@@ -101,7 +114,10 @@
         <article class="card chart-card loading" id="expense-category-chart-card">
             <div class="chart-card-head">
                 <div>
-                    <h2 th:text="#{dashboard.expenseCategoryChart.title}"></h2>
+                    <h2 class="chart-title">
+                        <i data-lucide="pie-chart" aria-hidden="true"></i>
+                        <span th:text="#{dashboard.expenseCategoryChart.title}"></span>
+                    </h2>
                     <p th:text="#{dashboard.expenseCategoryChart.subtitle}"></p>
                 </div>
                 <button class="btn btn-secondary" id="expense-category-drill-up" type="button" disabled>
@@ -118,7 +134,10 @@
         <article class="card chart-card loading" id="revenue-category-chart-card">
             <div class="chart-card-head">
                 <div>
-                    <h2 th:text="#{dashboard.revenueCategoryChart.title}"></h2>
+                    <h2 class="chart-title">
+                        <i data-lucide="chart-pie" aria-hidden="true"></i>
+                        <span th:text="#{dashboard.revenueCategoryChart.title}"></span>
+                    </h2>
                     <p th:text="#{dashboard.revenueCategoryChart.subtitle}"></p>
                 </div>
                 <button class="btn btn-secondary" id="revenue-category-drill-up" type="button" disabled>
@@ -136,7 +155,10 @@
     <section class="card chart-card loading" id="category-totals-chart-card">
         <div class="chart-card-head">
             <div>
-                <h2 th:text="#{dashboard.categoryTotalsChart.title}"></h2>
+                <h2 class="chart-title">
+                    <i data-lucide="chart-column-stacked" aria-hidden="true"></i>
+                    <span th:text="#{dashboard.categoryTotalsChart.title}"></span>
+                </h2>
                 <p th:text="#{dashboard.categoryTotalsChart.subtitle}"></p>
             </div>
             <button class="btn btn-secondary" id="category-totals-drill-up" type="button" disabled>
@@ -158,15 +180,17 @@
         variationUp: /*[[#{dashboard.variation.up}]]*/ "acima do período anterior",
         variationDown: /*[[#{dashboard.variation.down}]]*/ "abaixo do período anterior",
         variationStable: /*[[#{dashboard.variation.stable}]]*/ "igual ao período anterior",
-        chartMeta: /*[[#{dashboard.chart.meta}]]*/ "Período: {0} até {1} ({2})",
         chartGranularityDay: /*[[#{dashboard.chart.granularity.day}]]*/ "diário",
         chartGranularityMonth: /*[[#{dashboard.chart.granularity.month}]]*/ "mensal",
+        chartMetaGranularity: /*[[#{dashboard.chart.metaGranularity}]]*/ "Granularidade: {0}",
         chartSeriesAccumulated: /*[[#{dashboard.chart.series.accumulated}]]*/ "Saldo acumulado",
         chartSeriesPeriod: /*[[#{dashboard.chart.series.period}]]*/ "Movimentação no período",
         chartLoadError: /*[[#{dashboard.chart.error}]]*/ "Não foi possível carregar o gráfico.",
         summaryLoadError: /*[[#{dashboard.summary.error}]]*/ "Não foi possível carregar este indicador.",
         accountTypeBalancesLoadError: /*[[#{dashboard.accountTypeBalances.error}]]*/ "Não foi possível carregar os saldos por tipo de conta.",
         accountTypeBalancesEmpty: /*[[#{dashboard.accountTypeBalances.empty}]]*/ "Sem contas para exibir saldos por tipo.",
+        accountTypeBalancesLevelRoot: /*[[#{dashboard.accountTypeBalances.level.root}]]*/ "Nível: tipos de conta",
+        accountTypeBalancesLevelChild: /*[[#{dashboard.accountTypeBalances.level.child}]]*/ "Nível: contas do tipo {0}",
         revenueExpenseChartSeriesRevenue: /*[[#{dashboard.revenueExpenseChart.series.revenues}]]*/ "Receitas",
         revenueExpenseChartSeriesExpense: /*[[#{dashboard.revenueExpenseChart.series.expenses}]]*/ "Despesas",
         revenueExpenseChartLoadError: /*[[#{dashboard.revenueExpenseChart.error}]]*/ "Não foi possível carregar o gráfico de receitas vs despesas.",
@@ -182,7 +206,6 @@
         categoryTotalsChartEmpty: /*[[#{dashboard.categoryTotalsChart.empty}]]*/ "Sem dados no período",
         categoryTotalsChartLevelRoot: /*[[#{dashboard.categoryTotalsChart.level.root}]]*/ "Nível: categorias raiz",
         categoryTotalsChartLevelChild: /*[[#{dashboard.categoryTotalsChart.level.child}]]*/ "Nível: subcategorias de {0}",
-        chartMetaRange: /*[[#{dashboard.chart.metaRange}]]*/ "Período: {0} até {1}",
         accountTypeChecking: /*[[#{account.type.checking}]]*/ "Corrente",
         accountTypeCredit: /*[[#{account.type.credit}]]*/ "Crédito",
         accountTypeInvestment: /*[[#{account.type.investment}]]*/ "Investimento",
@@ -196,6 +219,8 @@
     const MONTH_FORMATTER = new Intl.DateTimeFormat("pt-BR", { month: "short", year: "numeric" });
     let accountTypeBalancesChart = null;
     let accountTypeBalancesPayload = [];
+    let accountBalancesPayload = [];
+    let accountTypeBalancesDrillDownType = null;
     let balanceChart = null;
     let chartPayload = null;
     let revenueExpenseChart = null;
@@ -220,14 +245,6 @@
 
     function formatMonth(isoDate) {
         return MONTH_FORMATTER.format(new Date(`${isoDate}T00:00:00`));
-    }
-
-    function replaceMeta(text, values) {
-        return text.replace("{0}", values[0]).replace("{1}", values[1]).replace("{2}", values[2]);
-    }
-
-    function replaceMetaRange(text, values) {
-        return text.replace("{0}", values[0]).replace("{1}", values[1]);
     }
 
     function getThemeColor(variableName, fallback) {
@@ -258,6 +275,7 @@
         const card = document.getElementById("account-type-balances-card");
         const meta = document.getElementById("account-type-balances-meta");
         const canvas = document.getElementById("account-type-balances-chart");
+        const drillUpButton = document.getElementById("account-type-balances-drill-up");
         if (!card || !meta || !canvas) {
             return;
         }
@@ -266,18 +284,32 @@
         card.classList.remove("loading");
         const rows = Array.isArray(items) ? items : [];
         accountTypeBalancesPayload = rows;
-        const hasBalances = rows.some((item) => Math.abs(Number(item.balance ?? 0)) > 0);
+        const accountRows = Array.isArray(accountBalancesPayload)
+            ? accountBalancesPayload.filter((item) => item.accountType === accountTypeBalancesDrillDownType)
+            : [];
+        const isDrillDown = accountTypeBalancesDrillDownType !== null;
+        const sourceRows = isDrillDown ? accountRows : rows;
+        const hasBalances = sourceRows.some((item) => Math.abs(Number(item.balance ?? 0)) > 0);
         const labels = hasBalances
-            ? rows.map((item) => accountTypeLabel(item.accountType))
+            ? sourceRows.map((item) => isDrillDown ? item.accountTitle : accountTypeLabel(item.accountType))
             : [i18n.accountTypeBalancesEmpty];
         const data = hasBalances
-            ? rows.map((item) => Math.abs(Number(item.balance ?? 0)))
+            ? sourceRows.map((item) => Math.abs(Number(item.balance ?? 0)))
             : [1];
         const colors = hasBalances
             ? ["#19647e", "#42e2b8", "#eb8a90", "#07004d", "#f0ec57", "#8cb7c7"]
             : ["#d7e0e8"];
 
-        meta.textContent = hasBalances ? "" : i18n.accountTypeBalancesEmpty;
+        if (!hasBalances) {
+            meta.textContent = i18n.accountTypeBalancesEmpty;
+        } else if (isDrillDown) {
+            meta.textContent = i18n.accountTypeBalancesLevelChild.replace("{0}", accountTypeLabel(accountTypeBalancesDrillDownType));
+        } else {
+            meta.textContent = i18n.accountTypeBalancesLevelRoot;
+        }
+        if (drillUpButton) {
+            drillUpButton.disabled = !isDrillDown;
+        }
 
         if (accountTypeBalancesChart) {
             accountTypeBalancesChart.destroy();
@@ -310,11 +342,27 @@
                                 if (!hasBalances) {
                                     return context.label;
                                 }
-                                const item = rows[context.dataIndex];
+                                const item = sourceRows[context.dataIndex];
                                 return `${context.label}: ${formatCurrency(item?.balance)}`;
                             }
                         }
                     }
+                },
+                onClick: (_, elements) => {
+                    if (!hasBalances || isDrillDown || elements.length === 0) {
+                        return;
+                    }
+                    const selectedItem = rows[elements[0].index];
+                    if (!selectedItem) {
+                        return;
+                    }
+                    const selectedType = selectedItem.accountType;
+                    const hasTypeAccounts = accountBalancesPayload.some((item) => item.accountType === selectedType);
+                    if (!hasTypeAccounts) {
+                        return;
+                    }
+                    accountTypeBalancesDrillDownType = selectedType;
+                    renderAccountTypeBalances(accountTypeBalancesPayload);
                 }
             }
         });
@@ -372,6 +420,8 @@
             renderMetric("summary-current-balance", data.currentBalance);
             renderMetric("summary-total-expenses", data.totalExpenses);
             renderMetric("summary-total-revenues", data.totalRevenues);
+            accountBalancesPayload = Array.isArray(data.accountBalances) ? data.accountBalances : [];
+            accountTypeBalancesDrillDownType = null;
             renderAccountTypeBalances(data.accountTypeBalances);
         } catch (error) {
             const balancesMeta = document.getElementById("account-type-balances-meta");
@@ -487,15 +537,8 @@
             chartPayload = await response.json();
             card.classList.remove("loading");
 
-            const granularityLabel = chartPayload.granularity === "MONTH"
-                ? i18n.chartGranularityMonth
-                : i18n.chartGranularityDay;
-
-            meta.textContent = replaceMeta(i18n.chartMeta, [
-                formatDate(chartPayload.startDate),
-                formatDate(chartPayload.endDate),
-                granularityLabel
-            ]);
+            const granularityLabel = chartPayload.granularity === "MONTH" ? i18n.chartGranularityMonth : i18n.chartGranularityDay;
+            meta.textContent = i18n.chartMetaGranularity.replace("{0}", granularityLabel);
 
             renderChart("accumulated");
         } catch (error) {
@@ -605,15 +648,8 @@
             revenueExpensePayload = await response.json();
             card.classList.remove("loading");
 
-            const granularityLabel = revenueExpensePayload.granularity === "MONTH"
-                ? i18n.chartGranularityMonth
-                : i18n.chartGranularityDay;
-
-            meta.textContent = replaceMeta(i18n.chartMeta, [
-                formatDate(revenueExpensePayload.startDate),
-                formatDate(revenueExpensePayload.endDate),
-                granularityLabel
-            ]);
+            const granularityLabel = revenueExpensePayload.granularity === "MONTH" ? i18n.chartGranularityMonth : i18n.chartGranularityDay;
+            meta.textContent = i18n.chartMetaGranularity.replace("{0}", granularityLabel);
 
             renderRevenueExpenseChart();
         } catch (error) {
@@ -789,14 +825,10 @@
             expenseCategoryPayload = await response.json();
             card.classList.remove("loading");
 
-            const periodLabel = replaceMetaRange(i18n.chartMetaRange, [
-                formatDate(expenseCategoryPayload.startDate),
-                formatDate(expenseCategoryPayload.endDate)
-            ]);
             const levelLabel = expenseCategoryPayload.currentParentCategoryName
                 ? i18n.expenseCategoryChartLevelChild.replace("{0}", expenseCategoryPayload.currentParentCategoryName)
                 : i18n.expenseCategoryChartLevelRoot;
-            meta.textContent = `${periodLabel} • ${levelLabel}`;
+            meta.textContent = levelLabel;
 
             expenseCategoryDrillUpParentId = expenseCategoryPayload.drillUpParentCategoryId;
             if (drillUpButton) {
@@ -834,14 +866,10 @@
             revenueCategoryPayload = await response.json();
             card.classList.remove("loading");
 
-            const periodLabel = replaceMetaRange(i18n.chartMetaRange, [
-                formatDate(revenueCategoryPayload.startDate),
-                formatDate(revenueCategoryPayload.endDate)
-            ]);
             const levelLabel = revenueCategoryPayload.currentParentCategoryName
                 ? i18n.revenueCategoryChartLevelChild.replace("{0}", revenueCategoryPayload.currentParentCategoryName)
                 : i18n.revenueCategoryChartLevelRoot;
-            meta.textContent = `${periodLabel} • ${levelLabel}`;
+            meta.textContent = levelLabel;
 
             revenueCategoryDrillUpParentId = revenueCategoryPayload.drillUpParentCategoryId;
             if (drillUpButton) {
@@ -972,17 +1000,13 @@
             categoryTotalsPayload = await response.json();
             card.classList.remove("loading");
 
-            const periodLabel = replaceMetaRange(i18n.chartMetaRange, [
-                formatDate(categoryTotalsPayload.startDate),
-                formatDate(categoryTotalsPayload.endDate)
-            ]);
             const levelLabel = categoryTotalsPayload.currentParentCategoryName
                 ? i18n.categoryTotalsChartLevelChild.replace("{0}", categoryTotalsPayload.currentParentCategoryName)
                 : i18n.categoryTotalsChartLevelRoot;
             const granularityLabel = categoryTotalsPayload.granularity === "MONTH"
                 ? i18n.chartGranularityMonth
                 : i18n.chartGranularityDay;
-            meta.textContent = `${periodLabel} • ${levelLabel} • ${granularityLabel}`;
+            meta.textContent = `${levelLabel} • ${i18n.chartMetaGranularity.replace("{0}", granularityLabel)}`;
 
             categoryTotalsDrillUpParentId = categoryTotalsPayload.drillUpParentCategoryId;
             if (drillUpButton) {
@@ -1047,6 +1071,14 @@
             renderRevenueCategoryChart();
             renderCategoryTotalsChart();
         });
+
+        const accountTypeDrillUpButton = document.getElementById("account-type-balances-drill-up");
+        if (accountTypeDrillUpButton) {
+            accountTypeDrillUpButton.addEventListener("click", () => {
+                accountTypeBalancesDrillDownType = null;
+                renderAccountTypeBalances(accountTypeBalancesPayload);
+            });
+        }
     });
 </script>
 <footer th:replace="~{fragments/footer :: appFooter}"></footer>

--- a/src/test/java/dev/ccosta/aisha/application/dashboard/DashboardServiceTest.java
+++ b/src/test/java/dev/ccosta/aisha/application/dashboard/DashboardServiceTest.java
@@ -103,6 +103,10 @@ class DashboardServiceTest {
         assertThat(summary.accountTypeBalances().get(0).balance()).isEqualByComparingTo("125.00");
         assertThat(summary.accountTypeBalances().get(1).balance()).isEqualByComparingTo("-60.00");
         assertThat(summary.accountTypeBalances().get(4).balance()).isEqualByComparingTo("0.00");
+        assertThat(summary.accountBalances()).extracting(item -> item.accountTitle())
+            .containsExactly("Conta Corrente", "Cartão");
+        assertThat(summary.accountBalances().get(0).balance()).isEqualByComparingTo("125.00");
+        assertThat(summary.accountBalances().get(1).balance()).isEqualByComparingTo("-60.00");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Improve dashboard usability and visual consistency by adding representative icons to each chart title. 
- Allow users to drill down from the "Saldos por tipo de conta" overview into the individual accounts of the selected account type. 
- Remove duplicate period text from each chart meta since the global date filter already exposes the selected period. 
- Provide account-level balances in the API payload to support the drill-down interaction.

### Description
- Added a new domain DTO `DashboardAccountBalance` and extended `DashboardSummary` to include `accountBalances` so account-level balances can be returned by the summary API. 
- Implemented `buildAccountBalances(...)` in `DashboardService` and mapped the new payload in `DashboardApiController` and `DashboardSummaryResponse`. 
- Updated the dashboard template `src/main/resources/templates/dashboard/index.html` to add Lucide icons for all chart titles, add a drill-up button for account-type balances, and adjust chart meta rendering to remove the period and show only level/granularity where appropriate. 
- Added small CSS rules in `src/main/resources/static/css/app.css` for `.chart-title` and adjusted the inline JavaScript in the template to implement drill-down behavior for the account-type balances chart, including new JS state `accountBalancesPayload` and `accountTypeBalancesDrillDownType`. 
- Added i18n entries in `messages.properties` and `messages_pt_BR.properties` for new labels and metadata text. 
- Updated `DashboardServiceTest` to assert account-level balances are produced by the summary.

### Testing
- Ran the full test suite with `mvn test` and it completed successfully with zero failures. 
- Ran the focused unit test with `mvn -Dtest=DashboardServiceTest test` and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7af652644833280ef11bf2439e19b)