### PR TITLE
[codex] Fix investment listings without text filters

### DIFF
--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/AssetRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/AssetRepositoryAdapter.java
@@ -4,11 +4,11 @@ import dev.ccosta.aisha.domain.investment.Asset;
 import dev.ccosta.aisha.domain.investment.AssetRepository;
 import dev.ccosta.aisha.domain.investment.AssetType;
 import dev.ccosta.aisha.domain.shared.PagedResult;
+import java.text.Normalizer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.text.Normalizer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
@@ -38,11 +38,11 @@ public class AssetRepositoryAdapter implements AssetRepository {
 
     @Override
     public PagedResult<Asset> findPageOrdered(AssetType type, String descriptionFilter, int page, int pageSize) {
-        Page<Asset> result = jpaAssetRepository.searchByFilters(
-            type,
-            normalizeTextFilter(descriptionFilter),
-            PageRequest.of(page, pageSize)
-        );
+        PageRequest pageRequest = PageRequest.of(page, pageSize);
+        String normalizedDescriptionFilter = normalizeTextFilter(descriptionFilter);
+        Page<Asset> result = normalizedDescriptionFilter == null
+            ? jpaAssetRepository.searchByFiltersWithoutDescription(type, pageRequest)
+            : jpaAssetRepository.searchByFilters(type, normalizedDescriptionFilter, pageRequest);
         return new PagedResult<>(result.getContent(), result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
     }
 

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/BrokerageNoteRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/BrokerageNoteRepositoryAdapter.java
@@ -34,15 +34,26 @@ public class BrokerageNoteRepositoryAdapter implements BrokerageNoteRepository {
         int page,
         int pageSize
     ) {
-        Page<BrokerageNote> result = jpaBrokerageNoteRepository.searchByFilters(
-            settlementStartDate,
-            settlementEndDate,
-            accountId,
-            tradeStartDate,
-            tradeEndDate,
-            normalizePrefixFilter(noteNumberPrefix),
-            PageRequest.of(page, pageSize)
-        );
+        PageRequest pageRequest = PageRequest.of(page, pageSize);
+        String normalizedNoteNumberPrefix = normalizePrefixFilter(noteNumberPrefix);
+        Page<BrokerageNote> result = normalizedNoteNumberPrefix == null
+            ? jpaBrokerageNoteRepository.searchByFiltersWithoutNoteNumber(
+                settlementStartDate,
+                settlementEndDate,
+                accountId,
+                tradeStartDate,
+                tradeEndDate,
+                pageRequest
+            )
+            : jpaBrokerageNoteRepository.searchByFilters(
+                settlementStartDate,
+                settlementEndDate,
+                accountId,
+                tradeStartDate,
+                tradeEndDate,
+                normalizedNoteNumberPrefix,
+                pageRequest
+            );
         return new PagedResult<>(result.getContent(), result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
     }
 

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/InvestmentOperationRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/InvestmentOperationRepositoryAdapter.java
@@ -48,15 +48,26 @@ public class InvestmentOperationRepositoryAdapter implements InvestmentOperation
         int page,
         int pageSize
     ) {
-        Page<InvestmentOperation> result = jpaInvestmentOperationRepository.searchByFilters(
-            startDate,
-            endDate,
-            normalizeTextFilter(assetFilter),
-            accountId,
-            operationType,
-            brokerageNoteId,
-            PageRequest.of(page, pageSize)
-        );
+        PageRequest pageRequest = PageRequest.of(page, pageSize);
+        String normalizedAssetFilter = normalizeTextFilter(assetFilter);
+        Page<InvestmentOperation> result = normalizedAssetFilter == null
+            ? jpaInvestmentOperationRepository.searchByFiltersWithoutAsset(
+                startDate,
+                endDate,
+                accountId,
+                operationType,
+                brokerageNoteId,
+                pageRequest
+            )
+            : jpaInvestmentOperationRepository.searchByFilters(
+                startDate,
+                endDate,
+                normalizedAssetFilter,
+                accountId,
+                operationType,
+                brokerageNoteId,
+                pageRequest
+            );
         return new PagedResult<>(result.getContent(), result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
     }
 

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/JpaAssetRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/JpaAssetRepository.java
@@ -25,6 +25,20 @@ public interface JpaAssetRepository extends JpaRepository<Asset, Long> {
         select a
         from Asset a
         where (:type is null or a.type = :type)
+        order by a.name asc, a.ticker asc, a.id asc
+        """
+    )
+    Page<Asset> searchByFiltersWithoutDescription(
+        @Param("type") AssetType type,
+        Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"openingPosition"})
+    @Query(
+        """
+        select a
+        from Asset a
+        where (:type is null or a.type = :type)
           and (
                 :descriptionFilter is null
                 or upper(

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/JpaBrokerageNoteRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/JpaBrokerageNoteRepository.java
@@ -27,10 +27,30 @@ public interface JpaBrokerageNoteRepository extends JpaRepository<BrokerageNote,
      * @param accountId optional account identifier
      * @param tradeStartDate optional inclusive trade start date
      * @param tradeEndDate optional inclusive trade end date
-     * @param noteNumberPrefix optional broker note number prefix
      * @param pageable pagination request
      * @return matching brokerage notes
      */
+    @EntityGraph(attributePaths = {"netEntry", "netEntry.account"})
+    @Query(
+        """
+        select n
+        from BrokerageNote n
+        where n.settlementDate between :settlementStartDate and :settlementEndDate
+          and (:accountId is null or n.netEntry.account.id = :accountId)
+          and (:tradeStartDate is null or n.tradeDate >= :tradeStartDate)
+          and (:tradeEndDate is null or n.tradeDate <= :tradeEndDate)
+        order by n.settlementDate desc, n.tradeDate desc, n.id desc
+        """
+    )
+    Page<BrokerageNote> searchByFiltersWithoutNoteNumber(
+        @Param("settlementStartDate") LocalDate settlementStartDate,
+        @Param("settlementEndDate") LocalDate settlementEndDate,
+        @Param("accountId") Long accountId,
+        @Param("tradeStartDate") LocalDate tradeStartDate,
+        @Param("tradeEndDate") LocalDate tradeEndDate,
+        Pageable pageable
+    );
+
     @EntityGraph(attributePaths = {"netEntry", "netEntry.account"})
     @Query(
         """

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/JpaInvestmentOperationRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/investment/JpaInvestmentOperationRepository.java
@@ -35,6 +35,27 @@ public interface JpaInvestmentOperationRepository extends JpaRepository<Investme
           and (:accountId is null or o.account.id = :accountId)
           and (:operationType is null or o.operationType = :operationType)
           and (:brokerageNoteId is null or o.brokerageNote.id = :brokerageNoteId)
+        order by o.tradeDate desc, o.id desc
+        """
+    )
+    Page<InvestmentOperation> searchByFiltersWithoutAsset(
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate,
+        @Param("accountId") Long accountId,
+        @Param("operationType") InvestmentOperationType operationType,
+        @Param("brokerageNoteId") Long brokerageNoteId,
+        Pageable pageable
+    );
+
+    @EntityGraph(attributePaths = {"asset", "account", "brokerageNote"})
+    @Query(
+        """
+        select o
+        from InvestmentOperation o
+        where (:brokerageNoteId is not null or o.settlementDate between :startDate and :endDate)
+          and (:accountId is null or o.account.id = :accountId)
+          and (:operationType is null or o.operationType = :operationType)
+          and (:brokerageNoteId is null or o.brokerageNote.id = :brokerageNoteId)
           and (
                 :assetFilter is null
                 or upper(

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/investment/AssetRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/investment/AssetRepositoryAdapterTest.java
@@ -1,0 +1,61 @@
+package dev.ccosta.aisha.infrastructure.persistence.investment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.ccosta.aisha.domain.investment.AssetType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class AssetRepositoryAdapterTest {
+
+    @Mock
+    private JpaAssetRepository jpaAssetRepository;
+
+    @InjectMocks
+    private AssetRepositoryAdapter assetRepositoryAdapter;
+
+    @Test
+    void shouldNormalizeDescriptionFilterBeforeQuerying() {
+        when(jpaAssetRepository.searchByFilters(nullable(AssetType.class), anyString(), any(Pageable.class)))
+            .thenReturn(Page.empty());
+
+        assetRepositoryAdapter.findPageOrdered(AssetType.STOCK, "Ação_100%", 0, 25);
+
+        ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jpaAssetRepository).searchByFilters(
+            nullable(AssetType.class),
+            descriptionCaptor.capture(),
+            any(Pageable.class)
+        );
+
+        assertThat(descriptionCaptor.getValue()).isEqualTo("ACAO\\_100\\%");
+    }
+
+    @Test
+    void shouldUseQueryWithoutDescriptionWhenFilterIsBlank() {
+        when(jpaAssetRepository.searchByFiltersWithoutDescription(nullable(AssetType.class), any(Pageable.class)))
+            .thenReturn(Page.empty());
+
+        assetRepositoryAdapter.findPageOrdered(AssetType.STOCK, "   ", 0, 25);
+
+        verify(jpaAssetRepository).searchByFiltersWithoutDescription(nullable(AssetType.class), any(Pageable.class));
+        verify(jpaAssetRepository, never()).searchByFilters(
+            nullable(AssetType.class),
+            anyString(),
+            any(Pageable.class)
+        );
+    }
+}

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/investment/BrokerageNoteRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/investment/BrokerageNoteRepositoryAdapterTest.java
@@ -1,0 +1,107 @@
+package dev.ccosta.aisha.infrastructure.persistence.investment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class BrokerageNoteRepositoryAdapterTest {
+
+    @Mock
+    private JpaBrokerageNoteRepository jpaBrokerageNoteRepository;
+
+    @InjectMocks
+    private BrokerageNoteRepositoryAdapter brokerageNoteRepositoryAdapter;
+
+    @Test
+    void shouldNormalizeNoteNumberPrefixBeforeQuerying() {
+        when(jpaBrokerageNoteRepository.searchByFilters(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            nullable(Long.class),
+            nullable(LocalDate.class),
+            nullable(LocalDate.class),
+            anyString(),
+            any(Pageable.class)
+        )).thenReturn(Page.empty());
+
+        brokerageNoteRepositoryAdapter.findPageOrdered(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            1L,
+            null,
+            null,
+            "nt_100%",
+            0,
+            25
+        );
+
+        ArgumentCaptor<String> noteNumberCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jpaBrokerageNoteRepository).searchByFilters(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            nullable(Long.class),
+            nullable(LocalDate.class),
+            nullable(LocalDate.class),
+            noteNumberCaptor.capture(),
+            any(Pageable.class)
+        );
+
+        assertThat(noteNumberCaptor.getValue()).isEqualTo("NT\\_100\\%");
+    }
+
+    @Test
+    void shouldUseQueryWithoutNoteNumberWhenFilterIsBlank() {
+        when(jpaBrokerageNoteRepository.searchByFiltersWithoutNoteNumber(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            nullable(Long.class),
+            nullable(LocalDate.class),
+            nullable(LocalDate.class),
+            any(Pageable.class)
+        )).thenReturn(Page.empty());
+
+        brokerageNoteRepositoryAdapter.findPageOrdered(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            1L,
+            null,
+            null,
+            "   ",
+            0,
+            25
+        );
+
+        verify(jpaBrokerageNoteRepository).searchByFiltersWithoutNoteNumber(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            nullable(Long.class),
+            nullable(LocalDate.class),
+            nullable(LocalDate.class),
+            any(Pageable.class)
+        );
+        verify(jpaBrokerageNoteRepository, never()).searchByFilters(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            nullable(Long.class),
+            nullable(LocalDate.class),
+            nullable(LocalDate.class),
+            anyString(),
+            any(Pageable.class)
+        );
+    }
+}

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/investment/InvestmentOperationRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/investment/InvestmentOperationRepositoryAdapterTest.java
@@ -1,0 +1,108 @@
+package dev.ccosta.aisha.infrastructure.persistence.investment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.ccosta.aisha.domain.investment.InvestmentOperationType;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class InvestmentOperationRepositoryAdapterTest {
+
+    @Mock
+    private JpaInvestmentOperationRepository jpaInvestmentOperationRepository;
+
+    @InjectMocks
+    private InvestmentOperationRepositoryAdapter investmentOperationRepositoryAdapter;
+
+    @Test
+    void shouldNormalizeAssetFilterBeforeQuerying() {
+        when(jpaInvestmentOperationRepository.searchByFilters(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            anyString(),
+            nullable(Long.class),
+            nullable(InvestmentOperationType.class),
+            nullable(Long.class),
+            any(Pageable.class)
+        )).thenReturn(Page.empty());
+
+        investmentOperationRepositoryAdapter.findPageOrdered(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            "Ação_100%",
+            1L,
+            InvestmentOperationType.BUY,
+            null,
+            0,
+            25
+        );
+
+        ArgumentCaptor<String> assetFilterCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jpaInvestmentOperationRepository).searchByFilters(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            assetFilterCaptor.capture(),
+            nullable(Long.class),
+            nullable(InvestmentOperationType.class),
+            nullable(Long.class),
+            any(Pageable.class)
+        );
+
+        assertThat(assetFilterCaptor.getValue()).isEqualTo("ACAO\\_100\\%");
+    }
+
+    @Test
+    void shouldUseQueryWithoutAssetWhenFilterIsBlank() {
+        when(jpaInvestmentOperationRepository.searchByFiltersWithoutAsset(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            nullable(Long.class),
+            nullable(InvestmentOperationType.class),
+            nullable(Long.class),
+            any(Pageable.class)
+        )).thenReturn(Page.empty());
+
+        investmentOperationRepositoryAdapter.findPageOrdered(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            "   ",
+            1L,
+            InvestmentOperationType.BUY,
+            null,
+            0,
+            25
+        );
+
+        verify(jpaInvestmentOperationRepository).searchByFiltersWithoutAsset(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            nullable(Long.class),
+            nullable(InvestmentOperationType.class),
+            nullable(Long.class),
+            any(Pageable.class)
+        );
+        verify(jpaInvestmentOperationRepository, never()).searchByFilters(
+            any(LocalDate.class),
+            any(LocalDate.class),
+            anyString(),
+            nullable(Long.class),
+            nullable(InvestmentOperationType.class),
+            nullable(Long.class),
+            any(Pageable.class)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes production failures in investment listing screens when optional text filters are submitted without values.

## Root Cause

The asset, investment operation, and brokerage note listing queries still received null textual filter parameters in JPQL expressions using `concat`/`like`. On PostgreSQL, that can lead Hibernate/JDBC to bind the parameter with an incompatible type and fail with `invalid input syntax for type bytea`.

## Changes

- Route blank asset, operation asset, and brokerage note number filters to JPQL queries that omit the textual predicate entirely.
- Keep the existing normalized/escaped text-filter query path when the user provides a value.
- Add adapter tests covering both blank-filter query selection and filled-filter normalization.

## Validation

- `./mvnw test`