### PR TITLE
[codex] Fix Rico brokerage note observation parsing

### DIFF
--- a/src/main/java/dev/ccosta/aisha/application/investment/importing/RicoPdfBrokerageNoteProcessor.java
+++ b/src/main/java/dev/ccosta/aisha/application/investment/importing/RicoPdfBrokerageNoteProcessor.java
@@ -269,11 +269,10 @@ public class RicoPdfBrokerageNoteProcessor implements BrokerageNoteProcessor {
     }
 
     private String operationNotes(String marketType, AssetDescriptor assetDescriptor) {
-        String notes = "Rico " + marketType + " - " + assetDescriptor.cleanedSpecification();
-        if (!assetDescriptor.observations().isEmpty()) {
-            notes += ". Observações: " + String.join("; ", assetDescriptor.observations());
+        if (assetDescriptor.observations().isEmpty()) {
+            return "Rico " + marketType + " - " + assetDescriptor.cleanedSpecification();
         }
-        return notes;
+        return String.join("; ", assetDescriptor.observations());
     }
 
     private InvestmentOperationType toOperationType(String side) {
@@ -283,7 +282,7 @@ public class RicoPdfBrokerageNoteProcessor implements BrokerageNoteProcessor {
     private AssetDescriptor describeAsset(String rawSpecification, Map<String, String> observationLegend) {
         List<String> tokens = new ArrayList<>(List.of(rawSpecification.trim().replaceAll("\\s+", " ").split(" ")));
         List<String> observations = new ArrayList<>();
-        while (!tokens.isEmpty() && TRAILING_MARKER_PATTERN.matcher(tokens.getLast()).matches()) {
+        while (!tokens.isEmpty() && isTrailingMarker(tokens.getLast(), observationLegend)) {
             String marker = tokens.removeLast();
             observations.addAll(0, expandObservationMarker(marker, observationLegend));
         }
@@ -302,7 +301,14 @@ public class RicoPdfBrokerageNoteProcessor implements BrokerageNoteProcessor {
         return new AssetDescriptor(String.join(" ", tokens), name, ticker, type, List.copyOf(observations));
     }
 
+    private boolean isTrailingMarker(String token, Map<String, String> observationLegend) {
+        return TRAILING_MARKER_PATTERN.matcher(token).matches() || observationLegend.containsKey(token);
+    }
+
     private List<String> expandObservationMarker(String marker, Map<String, String> observationLegend) {
+        if (observationLegend.containsKey(marker)) {
+            return List.of(observationLegend.get(marker));
+        }
         if (!OBSERVATION_REFERENCE_PATTERN.matcher(marker).matches()) {
             return List.of();
         }

--- a/src/test/java/dev/ccosta/aisha/application/investment/importing/RicoPdfBrokerageNoteProcessorTest.java
+++ b/src/test/java/dev/ccosta/aisha/application/investment/importing/RicoPdfBrokerageNoteProcessorTest.java
@@ -64,8 +64,7 @@ class RicoPdfBrokerageNoteProcessorTest {
         assertThat(parsedNote.operations().get(1).getAsset().getType()).isEqualTo(AssetType.FII);
         assertThat(parsedNote.operations().get(1).getAsset().getTicker()).isEqualTo("XPML11");
         assertThat(parsedNote.operations().get(1).getNotes())
-            .contains("Observações: Negócio direto; Corretora ou pessoa vinculada atuou na contra parte.")
-            .doesNotContain("#2");
+            .isEqualTo("Negócio direto; Corretora ou pessoa vinculada atuou na contra parte.");
     }
 
     @Test
@@ -122,6 +121,39 @@ class RicoPdfBrokerageNoteProcessorTest {
         assertThat(parsedNotes.get(1).brokerageNote().getNoteNumber()).isEqualTo("127651096");
         assertThat(parsedNotes.get(1).brokerageNote().getTotalCosts()).isEqualByComparingTo("2.83");
         assertThat(parsedNotes.get(1).operations()).hasSize(1);
+    }
+
+    @Test
+    void shouldRemoveLegacyObservationColumnMarkerFromAssetName() throws IOException {
+        byte[] pdf = pdfWithPages(List.of(List.of(
+            "NOTA DE NEGOCIAÇÃO",
+            "Nr. nota Folha Data pregão",
+            "46027 1 09/02/2015",
+            "Rico Investimentos - Grupo XP",
+            "C.N.P.J: 02.332.886/0016-82 Carta Patente:",
+            "Negócios realizados",
+            "Q Negociação C/V Tipo mercado Prazo Especificação do título Obs. (*) Quantidade Preço / Ajuste Valor Operação / Ajuste D/C",
+            "1-BOVESPA C VISTA ISHARES BOVA          CI H 50 47,10 2.355,00 D",
+            "1-BOVESPA C VISTA PETROBRAS          PN H 100 8,90 890,00 D",
+            "Taxa de liquidação 0,89 D",
+            "Total Bovespa / Soma 0,00 D",
+            "Total Custos / Despesas 19,60 D",
+            "Líquido para 12/02/2015 3.266,72 D",
+            "(*) Observações A - Posição futuro T - Liquidação pelo Bruto",
+            "8 - Liquidação Institucional H - Home Broker",
+            "Capitais e regiões metropolitanas: 3003-5465"
+        )));
+
+        List<ParsedBrokerageNote> parsedNotes = processor.process(request("rico-2015.pdf", pdf));
+
+        assertThat(parsedNotes).hasSize(1);
+        assertThat(parsedNotes.getFirst().operations()).hasSize(2);
+        assertThat(parsedNotes.getFirst().operations().getFirst().getAsset().getName()).isEqualTo("ISHARES BOVA CI");
+        assertThat(parsedNotes.getFirst().operations().getFirst().getAsset().getType()).isEqualTo(AssetType.ETF);
+        assertThat(parsedNotes.getFirst().operations().getFirst().getNotes()).isEqualTo("Home Broker");
+        assertThat(parsedNotes.getFirst().operations().get(1).getAsset().getName()).isEqualTo("PETROBRAS PN");
+        assertThat(parsedNotes.getFirst().operations().get(1).getAsset().getType()).isEqualTo(AssetType.STOCK);
+        assertThat(parsedNotes.getFirst().operations().get(1).getNotes()).isEqualTo("Home Broker");
     }
 
     private BrokerageNoteProcessingRequest request(String fileName, byte[] pdf) {


### PR DESCRIPTION
## Summary

Fixes Rico brokerage note imports for legacy PDFs where the `Obs.` column marker is extracted as part of the asset specification.

## What Changed

- Treats trailing operation markers found in the PDF observation legend as observation markers instead of asset-name text.
- Stores only the expanded footnote text in operation notes when a footnote marker exists.
- Adds parser coverage for the legacy `H - Home Broker` marker case and updates existing expectations for footnote-only notes.

## Validation

- `./mvnw test -Dtest=RicoPdfBrokerageNoteProcessorTest`
- `./mvnw test`