### PR TITLE
[codex] Persist backup archives and stabilize backup naming

### DIFF
--- a/src/main/java/dev/ccosta/aisha/application/backup/SystemBackupArchiveService.java
+++ b/src/main/java/dev/ccosta/aisha/application/backup/SystemBackupArchiveService.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.Map;
@@ -23,9 +22,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class SystemBackupArchiveService {
 
-    private static final DateTimeFormatter FILENAME_TIMESTAMP = DateTimeFormatter
-        .ofPattern("yyyyMMdd-HHmmss")
-        .withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter FILENAME_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
 
     private final DatabaseDumpService databaseDumpService;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -62,7 +59,7 @@ public class SystemBackupArchiveService {
             workDirectory = Files.createTempDirectory(backupDirectory, "work-");
             DatabaseBackupDump dump = databaseDumpService.dump(workDirectory);
             Instant completedAt = clock.instant();
-            String backupFilename = "aisha-backup-" + FILENAME_TIMESTAMP.format(startedAt) + ".zip";
+            String backupFilename = "aisha-backup-" + FILENAME_TIMESTAMP.withZone(clock.getZone()).format(startedAt) + ".zip";
             Path backupFile = backupDirectory.resolve(backupFilename);
             SystemBackupManifest manifest = new SystemBackupManifest(
                 startedAt.toString(),

--- a/src/test/java/dev/ccosta/aisha/application/backup/SystemBackupArchiveServiceTest.java
+++ b/src/test/java/dev/ccosta/aisha/application/backup/SystemBackupArchiveServiceTest.java
@@ -43,7 +43,7 @@ class SystemBackupArchiveServiceTest {
             "HSQLDB SCRIPT"
         ));
         ObjectMapper objectMapper = new ObjectMapper();
-        Clock clock = Clock.fixed(Instant.parse("2026-05-10T13:45:30Z"), ZoneId.of("UTC"));
+        Clock clock = Clock.fixed(Instant.parse("2026-05-10T13:45:30Z"), ZoneId.of("America/Sao_Paulo"));
         SystemBackupArchiveService service = new SystemBackupArchiveService(
             databaseDumpService,
             clock,


### PR DESCRIPTION
## Summary
- Document administrative automation strategy for backup and future system functions.
- Persist production backup archives under /var/lib/aisha/backups with Docker Compose volume mapping.
- Make backup archive filenames deterministic across host time zones by using the injected Clock zone.

## Validation
- ./mvnw test