### PR TITLE
[codex] Allow categories on investment-linked entries

### DIFF
--- a/src/main/java/dev/ccosta/aisha/application/entry/EntryService.java
+++ b/src/main/java/dev/ccosta/aisha/application/entry/EntryService.java
@@ -116,14 +116,9 @@ public class EntryService {
         existing.setMovementDate(updatedData.getMovementDate());
         existing.setSettlementDate(updatedData.getSettlementDate());
         existing.setDescription(updatedData.getDescription());
-        if (existing.isEquityEffect()) {
-            clearCategoryState(existing);
-        } else {
-            existing.setEntryEffect(EntryEffect.RESULT);
-            Category category = resolveCategory(categorySelection);
-            existing.setCategory(category);
-            applyCategorySuggestionFeedback(existing, category, categorySelection);
-        }
+        Category category = resolveCategory(categorySelection);
+        existing.setCategory(category);
+        applyCategorySuggestionFeedback(existing, category, categorySelection);
         existing.setNotes(updatedData.getNotes());
         existing.setAmount(updatedData.getAmount());
         applyManualMetadataForLegacyUpdate(existing);
@@ -272,13 +267,6 @@ public class EntryService {
                 ? EntryCategorySuggestionStatus.ACCEPTED
                 : EntryCategorySuggestionStatus.REJECTED
         );
-    }
-
-    private void clearCategoryState(Entry entry) {
-        entry.setCategory(null);
-        entry.setSuggestedCategory(null);
-        entry.setCategorySuggestionConfidence(null);
-        entry.setCategorySuggestionStatus(EntryCategorySuggestionStatus.NONE);
     }
 
     private void synchronizeLinkedInvestmentOperation(Entry entry) {

--- a/src/main/java/dev/ccosta/aisha/web/entry/EntryController.java
+++ b/src/main/java/dev/ccosta/aisha/web/entry/EntryController.java
@@ -673,12 +673,6 @@ public class EntryController {
     }
 
     private void fillCategorySuggestionState(Model model, EntryForm form) {
-        if (form != null && form.isEquityEntry()) {
-            model.addAttribute("suggestedCategory", null);
-            model.addAttribute("pendingCategorySuggestion", false);
-            model.addAttribute("showNewCategoryField", false);
-            return;
-        }
         if (form == null || form.getSuggestedCategoryId() == null) {
             model.addAttribute("suggestedCategory", null);
             model.addAttribute("pendingCategorySuggestion", false);
@@ -696,7 +690,7 @@ public class EntryController {
     }
 
     private void validateCategoryChoice(EntryForm form, BindingResult bindingResult) {
-        if (form != null && form.isEquityEntry()) {
+        if (form != null && form.isTransferEntry()) {
             return;
         }
         boolean hasCategoryId = effectiveCategoryId(form) != null;
@@ -755,7 +749,7 @@ public class EntryController {
     }
 
     private boolean shouldSuggestCategory(EntryForm form) {
-        if (form != null && form.isEquityEntry()) {
+        if (form != null && form.isTransferEntry()) {
             return false;
         }
         return effectiveCategoryId(form) == null
@@ -783,7 +777,6 @@ public class EntryController {
     private boolean shouldShowNewCategoryField(EntryForm form) {
         return form != null
             && !form.isTransferEntry()
-            && !form.isEquityEntry()
             && (isNewCategoryOptionSelected(form) || StringUtils.hasText(form.getNewCategoryTitle()));
     }
 
@@ -792,9 +785,6 @@ public class EntryController {
     }
 
     private Long effectiveCategoryId(EntryForm form) {
-        if (form != null && form.isEquityEntry()) {
-            return null;
-        }
         if (isNewCategoryOptionSelected(form)) {
             return null;
         }

--- a/src/main/resources/templates/entries/form.html
+++ b/src/main/resources/templates/entries/form.html
@@ -63,7 +63,7 @@
                     class="field-group"
                     th:fragment="categorySelectionSection"
                     th:object="${form}"
-                    th:if="${!form.equityEntry}">
+                    th:if="${!form.transferEntry}">
                     <input type="hidden" th:field="*{suggestedCategoryId}">
                     <input type="hidden" th:field="*{suggestedCategoryConfidence}">
                     <div class="field">
@@ -106,7 +106,7 @@
                 </div>
             </div>
 
-            <div class="field" th:if="${form.equityEntry}">
+            <div class="field" th:if="${form.transferEntry}">
                 <label th:text="#{entries.form.field.category}"></label>
                 <p class="helper" th:text="#{entries.form.transfer.noCategory}"></p>
             </div>

--- a/src/test/java/dev/ccosta/aisha/application/entry/EntryServiceTest.java
+++ b/src/test/java/dev/ccosta/aisha/application/entry/EntryServiceTest.java
@@ -448,7 +448,7 @@ class EntryServiceTest {
     }
 
     @Test
-    void shouldUpdateEquityEntryWithoutCategorySelection() {
+    void shouldUpdateEquityEntryCategoryAndPreserveEquityEffect() {
         Entry existing = newEntry("Nota de corretagem", new BigDecimal("-100.00"));
         existing.setEntryEffect(EntryEffect.EQUITY);
         existing.setSuggestedCategory(newCategory("Investimentos"));
@@ -456,19 +456,21 @@ class EntryServiceTest {
         existing.setCategorySuggestionStatus(EntryCategorySuggestionStatus.PENDING);
         Entry updatedData = newEntry("Nota de corretagem editada", new BigDecimal("-120.00"));
         Account account = newAccount("Conta investimentos");
+        Category category = newCategory("Investimentos");
 
         when(entryRepository.findById(1L)).thenReturn(Optional.of(existing));
         when(accountService.findById(6L)).thenReturn(account);
+        when(categoryService.findById(7L)).thenReturn(category);
         when(entryRepository.save(existing)).thenReturn(existing);
 
-        Entry updated = entryService.update(1L, updatedData, 6L, null);
+        Entry updated = entryService.update(1L, updatedData, 6L, selection(7L, null, null, null));
 
         assertThat(updated.getEntryEffect()).isEqualTo(EntryEffect.EQUITY);
-        assertThat(updated.getCategory()).isNull();
+        assertThat(updated.getCategory()).isSameAs(category);
         assertThat(updated.getSuggestedCategory()).isNull();
         assertThat(updated.getCategorySuggestionConfidence()).isNull();
         assertThat(updated.getCategorySuggestionStatus()).isEqualTo(EntryCategorySuggestionStatus.NONE);
-        verify(categoryService, never()).findById(org.mockito.ArgumentMatchers.anyLong());
+        verify(categoryService).findById(7L);
     }
 
     @Test

--- a/src/test/java/dev/ccosta/aisha/web/entry/EntryControllerTest.java
+++ b/src/test/java/dev/ccosta/aisha/web/entry/EntryControllerTest.java
@@ -133,6 +133,20 @@ class EntryControllerTest {
     }
 
     @Test
+    void shouldKeepCategoryControlsAvailableForEquityEntry() {
+        EntryForm form = baseForm();
+        form.setEquityEntry(true);
+        form.setCategoryId(-2L);
+        ConcurrentModel model = new ConcurrentModel();
+        when(categoryService.listHierarchyOptions()).thenReturn(List.of(new CategoryOption(1L, "Investimentos")));
+
+        String view = entryController.categorySuggestion(form, model);
+
+        assertThat(view).isEqualTo("entries/form :: categorySelectionSection");
+        assertThat(model.getAttribute("showNewCategoryField")).isEqualTo(true);
+    }
+
+    @Test
     void shouldRequireNewCategoryTitleWhenSpecialOptionIsSelected() {
         EntryForm form = baseForm();
         form.setCategoryId(-2L);


### PR DESCRIPTION
## Summary

- Allow regular investment-linked entries, including Treasury Direct purchase entries, to keep editable categories.
- Restrict the no-category form behavior to real transfer entries instead of all equity-effect entries.
- Update service and web tests to cover category editing for equity-effect entries.

## Root Cause

Treasury Direct purchase entries are regular entries with an equity accounting effect. The entry form and update service treated any equity-effect entry as categoryless, which reused the transfer-only category blocking behavior for non-transfer investment entries.

## Validation

- `./mvnw test -Dtest=EntryServiceTest,EntryControllerTest`
- `./mvnw test`
