### PR TITLE
[codex] Add advanced text search syntax

### DIFF
--- a/src/main/java/dev/ccosta/aisha/application/search/TextSearchQuery.java
+++ b/src/main/java/dev/ccosta/aisha/application/search/TextSearchQuery.java
@@ -1,0 +1,23 @@
+package dev.ccosta.aisha.application.search;
+
+import java.util.List;
+
+/**
+ * Represents a parsed text search expression with inclusive and exclusive terms.
+ */
+public record TextSearchQuery(List<TextSearchTerm> positiveTerms, List<TextSearchTerm> negativeTerms) {
+
+    public TextSearchQuery {
+        positiveTerms = List.copyOf(positiveTerms == null ? List.of() : positiveTerms);
+        negativeTerms = List.copyOf(negativeTerms == null ? List.of() : negativeTerms);
+    }
+
+    /**
+     * Indicates whether the query has at least one parsed term.
+     *
+     * @return true when positive or negative terms are present
+     */
+    public boolean hasTerms() {
+        return !positiveTerms.isEmpty() || !negativeTerms.isEmpty();
+    }
+}

--- a/src/main/java/dev/ccosta/aisha/application/search/TextSearchQueryParser.java
+++ b/src/main/java/dev/ccosta/aisha/application/search/TextSearchQueryParser.java
@@ -1,0 +1,207 @@
+package dev.ccosta.aisha.application.search;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.util.StringUtils;
+
+/**
+ * Parses listing text filters into a small database-safe search language.
+ */
+public class TextSearchQueryParser {
+
+    private static final String DIACRITICS_PATTERN = "\\p{M}+";
+
+    /**
+     * Parses a user-provided search expression.
+     *
+     * @param value raw filter text typed by the user
+     * @return parsed positive and negative terms, or an empty query for blank input
+     */
+    public TextSearchQuery parse(String value) {
+        if (!StringUtils.hasText(value)) {
+            return new TextSearchQuery(List.of(), List.of());
+        }
+
+        SearchScanner scanner = new SearchScanner(value.trim());
+        List<TextSearchTerm> positiveTerms = new ArrayList<>();
+        List<TextSearchTerm> negativeTerms = new ArrayList<>();
+        ParsedToken token;
+        while ((token = scanner.nextToken()) != null) {
+            TextSearchTerm term = toSearchTerm(token);
+            if (term == null) {
+                continue;
+            }
+            if (token.negative()) {
+                negativeTerms.add(term);
+            } else {
+                positiveTerms.add(term);
+            }
+        }
+        return new TextSearchQuery(positiveTerms, negativeTerms);
+    }
+
+    /**
+     * Normalizes searchable text using the same accent and case rules as parsed terms.
+     *
+     * @param value text to normalize
+     * @return uppercase text without diacritics, or an empty string for null input
+     */
+    public String normalizeText(String value) {
+        if (value == null) {
+            return "";
+        }
+        return Normalizer.normalize(value, Normalizer.Form.NFD)
+            .replaceAll(DIACRITICS_PATTERN, "")
+            .toUpperCase(Locale.ROOT);
+    }
+
+    private TextSearchTerm toSearchTerm(ParsedToken token) {
+        StringBuilder pattern = new StringBuilder("%");
+        StringBuilder literal = new StringBuilder();
+        boolean hasContent = false;
+
+        for (TokenCharacter character : token.characters()) {
+            if (character.wildcard() == Wildcard.ANY_SEQUENCE) {
+                flushLiteral(pattern, literal);
+                pattern.append('%');
+                hasContent = true;
+            } else if (character.wildcard() == Wildcard.SINGLE_CHARACTER) {
+                flushLiteral(pattern, literal);
+                pattern.append('_');
+                hasContent = true;
+            } else {
+                literal.append(character.value());
+                if (!Character.isWhitespace(character.value())) {
+                    hasContent = true;
+                }
+            }
+        }
+
+        flushLiteral(pattern, literal);
+        pattern.append('%');
+        if (!hasContent) {
+            return null;
+        }
+        return new TextSearchTerm(pattern.toString());
+    }
+
+    private void flushLiteral(StringBuilder pattern, StringBuilder literal) {
+        if (literal.isEmpty()) {
+            return;
+        }
+        pattern.append(escapeLikePattern(normalizeText(literal.toString())));
+        literal.setLength(0);
+    }
+
+    private String escapeLikePattern(String value) {
+        return value
+            .replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_");
+    }
+
+    private enum Wildcard {
+        NONE,
+        ANY_SEQUENCE,
+        SINGLE_CHARACTER
+    }
+
+    private record TokenCharacter(char value, Wildcard wildcard) {
+        private static TokenCharacter literal(char value) {
+            return new TokenCharacter(value, Wildcard.NONE);
+        }
+
+        private static TokenCharacter wildcard(Wildcard wildcard) {
+            return new TokenCharacter('\0', wildcard);
+        }
+    }
+
+    private record ParsedToken(boolean negative, List<TokenCharacter> characters) {
+    }
+
+    private static final class SearchScanner {
+
+        private final String value;
+        private int index;
+
+        private SearchScanner(String value) {
+            this.value = value;
+        }
+
+        private ParsedToken nextToken() {
+            skipWhitespace();
+            if (index >= value.length()) {
+                return null;
+            }
+
+            boolean negative = consumeNegativePrefix();
+            List<TokenCharacter> characters = index < value.length() && value.charAt(index) == '"'
+                ? readQuotedToken()
+                : readPlainToken();
+            return new ParsedToken(negative, characters);
+        }
+
+        private boolean consumeNegativePrefix() {
+            if (value.charAt(index) != '-' || index + 1 >= value.length() || Character.isWhitespace(value.charAt(index + 1))) {
+                return false;
+            }
+            index++;
+            return true;
+        }
+
+        private List<TokenCharacter> readQuotedToken() {
+            index++;
+            List<TokenCharacter> characters = new ArrayList<>();
+            while (index < value.length()) {
+                char current = value.charAt(index++);
+                if (current == '\\') {
+                    if (index < value.length()) {
+                        characters.add(TokenCharacter.literal(value.charAt(index++)));
+                    } else {
+                        characters.add(TokenCharacter.literal(current));
+                    }
+                } else if (current == '"') {
+                    break;
+                } else {
+                    addCharacter(characters, current);
+                }
+            }
+            return characters;
+        }
+
+        private List<TokenCharacter> readPlainToken() {
+            List<TokenCharacter> characters = new ArrayList<>();
+            while (index < value.length() && !Character.isWhitespace(value.charAt(index))) {
+                char current = value.charAt(index++);
+                if (current == '\\') {
+                    if (index < value.length()) {
+                        characters.add(TokenCharacter.literal(value.charAt(index++)));
+                    } else {
+                        characters.add(TokenCharacter.literal(current));
+                    }
+                } else {
+                    addCharacter(characters, current);
+                }
+            }
+            return characters;
+        }
+
+        private void addCharacter(List<TokenCharacter> characters, char current) {
+            if (current == '*') {
+                characters.add(TokenCharacter.wildcard(Wildcard.ANY_SEQUENCE));
+            } else if (current == '?') {
+                characters.add(TokenCharacter.wildcard(Wildcard.SINGLE_CHARACTER));
+            } else {
+                characters.add(TokenCharacter.literal(current));
+            }
+        }
+
+        private void skipWhitespace() {
+            while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+                index++;
+            }
+        }
+    }
+}

--- a/src/main/java/dev/ccosta/aisha/application/search/TextSearchTerm.java
+++ b/src/main/java/dev/ccosta/aisha/application/search/TextSearchTerm.java
@@ -1,0 +1,13 @@
+package dev.ccosta.aisha.application.search;
+
+/**
+ * Represents one parsed text search term and its normalized SQL LIKE pattern.
+ */
+public record TextSearchTerm(String likePattern) {
+
+    public TextSearchTerm {
+        if (likePattern == null || likePattern.isBlank()) {
+            throw new IllegalArgumentException("Search term pattern is required");
+        }
+    }
+}

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/asset/AssetRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/asset/AssetRepositoryAdapter.java
@@ -1,25 +1,29 @@
 package dev.ccosta.aisha.infrastructure.persistence.asset;
 
+import dev.ccosta.aisha.application.search.TextSearchQuery;
+import dev.ccosta.aisha.application.search.TextSearchQueryParser;
 import dev.ccosta.aisha.domain.asset.Asset;
 import dev.ccosta.aisha.domain.asset.AssetRepository;
 import dev.ccosta.aisha.domain.asset.AssetType;
 import dev.ccosta.aisha.domain.shared.PagedResult;
-import java.text.Normalizer;
+import dev.ccosta.aisha.infrastructure.persistence.search.TextSearchPredicateBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.StringUtils;
 
 @Repository
 public class AssetRepositoryAdapter implements AssetRepository {
 
-    private static final String DIACRITICS_PATTERN = "\\p{M}+";
-
     private final JpaAssetRepository jpaAssetRepository;
+    private final TextSearchQueryParser textSearchQueryParser = new TextSearchQueryParser();
 
     public AssetRepositoryAdapter(JpaAssetRepository jpaAssetRepository) {
         this.jpaAssetRepository = jpaAssetRepository;
@@ -38,11 +42,11 @@ public class AssetRepositoryAdapter implements AssetRepository {
 
     @Override
     public PagedResult<Asset> findPageOrdered(AssetType type, String descriptionFilter, int page, int pageSize) {
-        PageRequest pageRequest = PageRequest.of(page, pageSize);
-        String normalizedDescriptionFilter = normalizeTextFilter(descriptionFilter);
-        Page<Asset> result = normalizedDescriptionFilter == null
-            ? jpaAssetRepository.searchByFiltersWithoutDescription(type, pageRequest)
-            : jpaAssetRepository.searchByFilters(type, normalizedDescriptionFilter, pageRequest);
+        PageRequest pageRequest = PageRequest.of(page, pageSize, Sort.by(Sort.Order.asc("name"), Sort.Order.asc("ticker"), Sort.Order.asc("id")));
+        Page<Asset> result = jpaAssetRepository.findAll(
+            assetSpecification(type, textSearchQueryParser.parse(descriptionFilter)),
+            pageRequest
+        );
         return new PagedResult<>(result.getContent(), result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
     }
 
@@ -81,19 +85,21 @@ public class AssetRepositoryAdapter implements AssetRepository {
         jpaAssetRepository.deleteAllByIdInBatch(ids);
     }
 
-    private String normalizeTextFilter(String value) {
-        if (!StringUtils.hasText(value)) {
-            return null;
-        }
-        String normalized = Normalizer.normalize(value.trim(), Normalizer.Form.NFD)
-            .replaceAll(DIACRITICS_PATTERN, "");
-        return escapeLikePattern(normalized).toUpperCase(Locale.ROOT);
-    }
-
-    private String escapeLikePattern(String value) {
-        return value
-            .replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_");
+    private Specification<Asset> assetSpecification(AssetType type, TextSearchQuery descriptionQuery) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (type != null) {
+                predicates.add(cb.equal(root.get("type"), type));
+            }
+            Expression<String> searchableText = cb.concat(
+                cb.concat(cb.concat(cb.coalesce(root.get("name"), ""), " "), cb.coalesce(root.get("ticker"), "")),
+                cb.concat(" ", cb.coalesce(root.get("issuer"), ""))
+            );
+            Predicate textPredicate = TextSearchPredicateBuilder.build(cb, searchableText, descriptionQuery);
+            if (textPredicate != null) {
+                predicates.add(textPredicate);
+            }
+            return cb.and(predicates.toArray(Predicate[]::new));
+        };
     }
 }

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/asset/JpaAssetRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/asset/JpaAssetRepository.java
@@ -1,17 +1,15 @@
 package dev.ccosta.aisha.infrastructure.persistence.asset;
 
 import dev.ccosta.aisha.domain.asset.Asset;
-import dev.ccosta.aisha.domain.asset.AssetType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface JpaAssetRepository extends JpaRepository<Asset, Long> {
+public interface JpaAssetRepository extends JpaRepository<Asset, Long>, JpaSpecificationExecutor<Asset> {
 
     @EntityGraph(attributePaths = {"openingPosition"})
     List<Asset> findAllByOrderByNameAscTickerAscIdAsc();
@@ -20,45 +18,7 @@ public interface JpaAssetRepository extends JpaRepository<Asset, Long> {
     Page<Asset> findAllByOrderByNameAscTickerAscIdAsc(Pageable pageable);
 
     @EntityGraph(attributePaths = {"openingPosition"})
-    @Query(
-        """
-        select a
-        from Asset a
-        where (:type is null or a.type = :type)
-        order by a.name asc, a.ticker asc, a.id asc
-        """
-    )
-    Page<Asset> searchByFiltersWithoutDescription(
-        @Param("type") AssetType type,
-        Pageable pageable
-    );
-
-    @EntityGraph(attributePaths = {"openingPosition"})
-    @Query(
-        """
-        select a
-        from Asset a
-        where (:type is null or a.type = :type)
-          and (
-                :descriptionFilter is null
-                or upper(
-                    function(
-                        'translate',
-                        concat(coalesce(a.name, ''), ' ', coalesce(a.ticker, ''), ' ', coalesce(a.issuer, '')),
-                        'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ',
-                        'AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn'
-                    )
-                )
-                    like concat('%', :descriptionFilter, '%') escape '\\'
-          )
-        order by a.name asc, a.ticker asc, a.id asc
-        """
-    )
-    Page<Asset> searchByFilters(
-        @Param("type") AssetType type,
-        @Param("descriptionFilter") String descriptionFilter,
-        Pageable pageable
-    );
+    Page<Asset> findAll(org.springframework.data.jpa.domain.Specification<Asset> specification, Pageable pageable);
 
     @Override
     @EntityGraph(attributePaths = {"openingPosition"})

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/brokeragenote/BrokerageNoteRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/brokeragenote/BrokerageNoteRepositoryAdapter.java
@@ -1,17 +1,22 @@
 package dev.ccosta.aisha.infrastructure.persistence.brokeragenote;
 
+import dev.ccosta.aisha.application.search.TextSearchQuery;
+import dev.ccosta.aisha.application.search.TextSearchQueryParser;
 import dev.ccosta.aisha.domain.brokeragenote.BrokerageNote;
 import dev.ccosta.aisha.domain.brokeragenote.BrokerageNoteRepository;
 import dev.ccosta.aisha.domain.shared.PagedResult;
+import dev.ccosta.aisha.infrastructure.persistence.search.TextSearchPredicateBuilder;
+import jakarta.persistence.criteria.Predicate;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.StringUtils;
 
 /**
  * Adapts Spring Data brokerage note persistence to the domain repository contract.
@@ -20,6 +25,7 @@ import org.springframework.util.StringUtils;
 public class BrokerageNoteRepositoryAdapter implements BrokerageNoteRepository {
 
     private final JpaBrokerageNoteRepository jpaBrokerageNoteRepository;
+    private final TextSearchQueryParser textSearchQueryParser = new TextSearchQueryParser();
 
     public BrokerageNoteRepositoryAdapter(JpaBrokerageNoteRepository jpaBrokerageNoteRepository) {
         this.jpaBrokerageNoteRepository = jpaBrokerageNoteRepository;
@@ -36,26 +42,22 @@ public class BrokerageNoteRepositoryAdapter implements BrokerageNoteRepository {
         int page,
         int pageSize
     ) {
-        PageRequest pageRequest = PageRequest.of(page, pageSize);
-        String normalizedNoteNumberPrefix = normalizePrefixFilter(noteNumberPrefix);
-        Page<BrokerageNote> result = normalizedNoteNumberPrefix == null
-            ? jpaBrokerageNoteRepository.searchByFiltersWithoutNoteNumber(
+        PageRequest pageRequest = PageRequest.of(
+            page,
+            pageSize,
+            Sort.by(Sort.Order.desc("settlementDate"), Sort.Order.desc("tradeDate"), Sort.Order.desc("id"))
+        );
+        Page<BrokerageNote> result = jpaBrokerageNoteRepository.findAll(
+            brokerageNoteSpecification(
                 settlementStartDate,
                 settlementEndDate,
                 accountId,
                 tradeStartDate,
                 tradeEndDate,
-                pageRequest
-            )
-            : jpaBrokerageNoteRepository.searchByFilters(
-                settlementStartDate,
-                settlementEndDate,
-                accountId,
-                tradeStartDate,
-                tradeEndDate,
-                normalizedNoteNumberPrefix,
-                pageRequest
-            );
+                textSearchQueryParser.parse(noteNumberPrefix)
+            ),
+            pageRequest
+        );
         return new PagedResult<>(result.getContent(), result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
     }
 
@@ -97,17 +99,31 @@ public class BrokerageNoteRepositoryAdapter implements BrokerageNoteRepository {
         return jpaBrokerageNoteRepository.save(brokerageNote);
     }
 
-    private String normalizePrefixFilter(String value) {
-        if (!StringUtils.hasText(value)) {
-            return null;
-        }
-        return escapeLikePattern(value.trim()).toUpperCase(Locale.ROOT);
-    }
-
-    private String escapeLikePattern(String value) {
-        return value
-            .replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_");
+    private Specification<BrokerageNote> brokerageNoteSpecification(
+        LocalDate settlementStartDate,
+        LocalDate settlementEndDate,
+        Long accountId,
+        LocalDate tradeStartDate,
+        LocalDate tradeEndDate,
+        TextSearchQuery noteNumberQuery
+    ) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.between(root.get("settlementDate"), settlementStartDate, settlementEndDate));
+            if (accountId != null) {
+                predicates.add(cb.equal(root.get("netEntry").get("account").get("id"), accountId));
+            }
+            if (tradeStartDate != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("tradeDate"), tradeStartDate));
+            }
+            if (tradeEndDate != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("tradeDate"), tradeEndDate));
+            }
+            Predicate textPredicate = TextSearchPredicateBuilder.build(cb, root.get("noteNumber"), noteNumberQuery);
+            if (textPredicate != null) {
+                predicates.add(textPredicate);
+            }
+            return cb.and(predicates.toArray(Predicate[]::new));
+        };
     }
 }

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/brokeragenote/JpaBrokerageNoteRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/brokeragenote/JpaBrokerageNoteRepository.java
@@ -9,13 +9,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.query.Param;
 
 /**
  * Spring Data repository for imported brokerage notes.
  */
-public interface JpaBrokerageNoteRepository extends JpaRepository<BrokerageNote, Long> {
+public interface JpaBrokerageNoteRepository extends JpaRepository<BrokerageNote, Long>, JpaSpecificationExecutor<BrokerageNote> {
 
     @Override
     @EntityGraph(attributePaths = {"netEntry", "netEntry.account"})
@@ -39,46 +39,8 @@ public interface JpaBrokerageNoteRepository extends JpaRepository<BrokerageNote,
      * @return matching brokerage notes
      */
     @EntityGraph(attributePaths = {"netEntry", "netEntry.account"})
-    @Query(
-        """
-        select n
-        from BrokerageNote n
-        where n.settlementDate between :settlementStartDate and :settlementEndDate
-          and (:accountId is null or n.netEntry.account.id = :accountId)
-          and (:tradeStartDate is null or n.tradeDate >= :tradeStartDate)
-          and (:tradeEndDate is null or n.tradeDate <= :tradeEndDate)
-        order by n.settlementDate desc, n.tradeDate desc, n.id desc
-        """
-    )
-    Page<BrokerageNote> searchByFiltersWithoutNoteNumber(
-        @Param("settlementStartDate") LocalDate settlementStartDate,
-        @Param("settlementEndDate") LocalDate settlementEndDate,
-        @Param("accountId") Long accountId,
-        @Param("tradeStartDate") LocalDate tradeStartDate,
-        @Param("tradeEndDate") LocalDate tradeEndDate,
-        Pageable pageable
-    );
-
-    @EntityGraph(attributePaths = {"netEntry", "netEntry.account"})
-    @Query(
-        """
-        select n
-        from BrokerageNote n
-        where n.settlementDate between :settlementStartDate and :settlementEndDate
-          and (:accountId is null or n.netEntry.account.id = :accountId)
-          and (:tradeStartDate is null or n.tradeDate >= :tradeStartDate)
-          and (:tradeEndDate is null or n.tradeDate <= :tradeEndDate)
-          and (:noteNumberPrefix is null or upper(n.noteNumber) like concat(:noteNumberPrefix, '%') escape '\\')
-        order by n.settlementDate desc, n.tradeDate desc, n.id desc
-        """
-    )
-    Page<BrokerageNote> searchByFilters(
-        @Param("settlementStartDate") LocalDate settlementStartDate,
-        @Param("settlementEndDate") LocalDate settlementEndDate,
-        @Param("accountId") Long accountId,
-        @Param("tradeStartDate") LocalDate tradeStartDate,
-        @Param("tradeEndDate") LocalDate tradeEndDate,
-        @Param("noteNumberPrefix") String noteNumberPrefix,
+    Page<BrokerageNote> findAll(
+        org.springframework.data.jpa.domain.Specification<BrokerageNote> specification,
         Pageable pageable
     );
 

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapter.java
@@ -1,25 +1,31 @@
 package dev.ccosta.aisha.infrastructure.persistence.entry;
 
+import dev.ccosta.aisha.application.search.TextSearchQuery;
+import dev.ccosta.aisha.application.search.TextSearchQueryParser;
 import dev.ccosta.aisha.domain.entry.Entry;
 import dev.ccosta.aisha.domain.entry.categorization.EntryCategorySuggestionStatus;
 import dev.ccosta.aisha.domain.entry.categorization.EntryCategoryTrainingExample;
 import dev.ccosta.aisha.domain.entry.EntryRepository;
 import dev.ccosta.aisha.domain.shared.PagedResult;
+import dev.ccosta.aisha.infrastructure.persistence.search.TextSearchPredicateBuilder;
+import jakarta.persistence.criteria.Predicate;
 import java.math.BigDecimal;
-import java.text.Normalizer;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class EntryRepositoryAdapter implements EntryRepository {
 
     private final JpaEntryRepository jpaEntryRepository;
+    private final TextSearchQueryParser textSearchQueryParser = new TextSearchQueryParser();
 
     public EntryRepositoryAdapter(JpaEntryRepository jpaEntryRepository) {
         this.jpaEntryRepository = jpaEntryRepository;
@@ -37,30 +43,20 @@ public class EntryRepositoryAdapter implements EntryRepository {
         int page,
         int pageSize
     ) {
-        PageRequest pageRequest = PageRequest.of(page, pageSize);
-        String normalizedDescriptionFilter = normalizeDescriptionFilter(descriptionFilter);
-        Page<Entry> result = normalizedDescriptionFilter == null
-            ? jpaEntryRepository.searchBySettlementDateBetweenAndFiltersWithoutDescription(
+        PageRequest pageRequest = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("settlementDate"), Sort.Order.desc("id")));
+        TextSearchQuery descriptionQuery = textSearchQueryParser.parse(descriptionFilter);
+        Page<Entry> result = jpaEntryRepository.findAll(
+            entrySpecification(
                 startDate,
                 endDate,
                 accountId,
                 categoryId,
+                descriptionQuery,
                 onlyWithoutCategory,
-                onlyPendingCategorySuggestions,
-                EntryCategorySuggestionStatus.PENDING,
-                pageRequest
-            )
-            : jpaEntryRepository.searchBySettlementDateBetweenAndFilters(
-                startDate,
-                endDate,
-                accountId,
-                categoryId,
-                normalizedDescriptionFilter,
-                onlyWithoutCategory,
-                onlyPendingCategorySuggestions,
-                EntryCategorySuggestionStatus.PENDING,
-                pageRequest
-            );
+                onlyPendingCategorySuggestions
+            ),
+            pageRequest
+        );
         return new PagedResult<>(
             result.getContent(),
             result.getNumber(),
@@ -160,29 +156,34 @@ public class EntryRepositoryAdapter implements EntryRepository {
         jpaEntryRepository.deleteAllByIdInBatch(ids);
     }
 
-    private String normalizeDescriptionFilter(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        if (value.isBlank()) {
-            return null;
-        }
-
-        String normalized = Normalizer.normalize(value, Normalizer.Form.NFD)
-            .replaceAll("\\p{M}+", "");
-
-        return escapeLikePattern(normalized).toUpperCase(Locale.ROOT);
-    }
-
-    private String escapeLikePattern(String value) {
-        if (value == null) {
-            return null;
-        }
-
-        return value
-            .replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_");
+    private Specification<Entry> entrySpecification(
+        LocalDate startDate,
+        LocalDate endDate,
+        Long accountId,
+        Long categoryId,
+        TextSearchQuery descriptionQuery,
+        boolean onlyWithoutCategory,
+        boolean onlyPendingCategorySuggestions
+    ) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.between(root.get("settlementDate"), startDate, endDate));
+            if (accountId != null) {
+                predicates.add(cb.equal(root.get("account").get("id"), accountId));
+            }
+            if (onlyWithoutCategory) {
+                predicates.add(cb.isNull(root.get("category")));
+            } else if (categoryId != null) {
+                predicates.add(cb.equal(root.get("category").get("id"), categoryId));
+            }
+            if (onlyPendingCategorySuggestions) {
+                predicates.add(cb.equal(root.get("categorySuggestionStatus"), EntryCategorySuggestionStatus.PENDING));
+            }
+            Predicate textPredicate = TextSearchPredicateBuilder.build(cb, root.get("description"), descriptionQuery);
+            if (textPredicate != null) {
+                predicates.add(textPredicate);
+            }
+            return cb.and(predicates.toArray(Predicate[]::new));
+        };
     }
 }

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepository.java
@@ -1,7 +1,6 @@
 package dev.ccosta.aisha.infrastructure.persistence.entry;
 
 import dev.ccosta.aisha.domain.entry.Entry;
-import dev.ccosta.aisha.domain.entry.categorization.EntryCategorySuggestionStatus;
 import dev.ccosta.aisha.domain.entry.categorization.EntryCategoryTrainingExample;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -11,82 +10,17 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface JpaEntryRepository extends JpaRepository<Entry, Long> {
+public interface JpaEntryRepository extends JpaRepository<Entry, Long>, JpaSpecificationExecutor<Entry> {
 
     @EntityGraph(attributePaths = {"account", "category", "suggestedCategory"})
     Optional<Entry> findWithDetailsById(Long id);
 
     @EntityGraph(attributePaths = {"account", "category", "suggestedCategory"})
-    @Query(
-        """
-        select e
-        from Entry e
-        where e.settlementDate between :startDate and :endDate
-          and (:accountId is null or e.account.id = :accountId)
-          and (
-                (:onlyWithoutCategory = true and e.category is null)
-                or (:onlyWithoutCategory = false and (:categoryId is null or e.category.id = :categoryId))
-          )
-          and (:onlyPendingCategorySuggestions = false or e.categorySuggestionStatus = :pendingStatus)
-        order by e.settlementDate desc, e.id desc
-        """
-    )
-    Page<Entry> searchBySettlementDateBetweenAndFiltersWithoutDescription(
-        LocalDate startDate,
-        LocalDate endDate,
-        @Param("accountId") Long accountId,
-        @Param("categoryId") Long categoryId,
-        @Param("onlyWithoutCategory") boolean onlyWithoutCategory,
-        @Param("onlyPendingCategorySuggestions") boolean onlyPendingCategorySuggestions,
-        @Param("pendingStatus") EntryCategorySuggestionStatus pendingStatus,
-        Pageable pageable
-    );
-
-    @EntityGraph(attributePaths = {"account", "category", "suggestedCategory"})
-    @Query(
-        """
-        select e
-        from Entry e
-        where e.settlementDate between :startDate and :endDate
-          and (:accountId is null or e.account.id = :accountId)
-          and (
-                (:onlyWithoutCategory = true and e.category is null)
-                or (:onlyWithoutCategory = false and (:categoryId is null or e.category.id = :categoryId))
-          )
-          and (
-                :descriptionFilter is null
-                or upper(
-                    function(
-                        'translate',
-                        e.description,
-                        'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ',
-                        'AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn'
-                    )
-                )
-                    like concat(
-                        '%',
-                        :descriptionFilter,
-                        '%'
-                    ) escape '\\'
-          )
-          and (:onlyPendingCategorySuggestions = false or e.categorySuggestionStatus = :pendingStatus)
-        order by e.settlementDate desc, e.id desc
-        """
-    )
-    Page<Entry> searchBySettlementDateBetweenAndFilters(
-        LocalDate startDate,
-        LocalDate endDate,
-        @Param("accountId") Long accountId,
-        @Param("categoryId") Long categoryId,
-        @Param("descriptionFilter") String descriptionFilter,
-        @Param("onlyWithoutCategory") boolean onlyWithoutCategory,
-        @Param("onlyPendingCategorySuggestions") boolean onlyPendingCategorySuggestions,
-        @Param("pendingStatus") EntryCategorySuggestionStatus pendingStatus,
-        Pageable pageable
-    );
+    Page<Entry> findAll(org.springframework.data.jpa.domain.Specification<Entry> specification, Pageable pageable);
 
     @EntityGraph(attributePaths = {"account", "category", "suggestedCategory"})
     List<Entry> findBySettlementDateLessThanEqualOrderBySettlementDateAscIdAsc(LocalDate endDate);

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/operation/InvestmentOperationRepositoryAdapter.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/operation/InvestmentOperationRepositoryAdapter.java
@@ -1,26 +1,30 @@
 package dev.ccosta.aisha.infrastructure.persistence.operation;
 
+import dev.ccosta.aisha.application.search.TextSearchQuery;
+import dev.ccosta.aisha.application.search.TextSearchQueryParser;
 import dev.ccosta.aisha.domain.operation.InvestmentOperation;
 import dev.ccosta.aisha.domain.operation.InvestmentOperationRepository;
 import dev.ccosta.aisha.domain.operation.InvestmentOperationType;
 import dev.ccosta.aisha.domain.shared.PagedResult;
-import java.text.Normalizer;
+import dev.ccosta.aisha.infrastructure.persistence.search.TextSearchPredicateBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.StringUtils;
 
 @Repository
 public class InvestmentOperationRepositoryAdapter implements InvestmentOperationRepository {
 
-    private static final String DIACRITICS_PATTERN = "\\p{M}+";
-
     private final JpaInvestmentOperationRepository jpaInvestmentOperationRepository;
+    private final TextSearchQueryParser textSearchQueryParser = new TextSearchQueryParser();
 
     public InvestmentOperationRepositoryAdapter(JpaInvestmentOperationRepository jpaInvestmentOperationRepository) {
         this.jpaInvestmentOperationRepository = jpaInvestmentOperationRepository;
@@ -48,26 +52,18 @@ public class InvestmentOperationRepositoryAdapter implements InvestmentOperation
         int page,
         int pageSize
     ) {
-        PageRequest pageRequest = PageRequest.of(page, pageSize);
-        String normalizedAssetFilter = normalizeTextFilter(assetFilter);
-        Page<InvestmentOperation> result = normalizedAssetFilter == null
-            ? jpaInvestmentOperationRepository.searchByFiltersWithoutAsset(
+        PageRequest pageRequest = PageRequest.of(page, pageSize, Sort.by(Sort.Order.desc("tradeDate"), Sort.Order.desc("id")));
+        Page<InvestmentOperation> result = jpaInvestmentOperationRepository.findAll(
+            operationSpecification(
                 startDate,
                 endDate,
+                textSearchQueryParser.parse(assetFilter),
                 accountId,
                 operationType,
-                brokerageNoteId,
-                pageRequest
-            )
-            : jpaInvestmentOperationRepository.searchByFilters(
-                startDate,
-                endDate,
-                normalizedAssetFilter,
-                accountId,
-                operationType,
-                brokerageNoteId,
-                pageRequest
-            );
+                brokerageNoteId
+            ),
+            pageRequest
+        );
         return new PagedResult<>(result.getContent(), result.getNumber(), result.getSize(), result.getTotalElements(), result.getTotalPages());
     }
 
@@ -111,19 +107,36 @@ public class InvestmentOperationRepositoryAdapter implements InvestmentOperation
         jpaInvestmentOperationRepository.deleteAllByIdInBatch(ids);
     }
 
-    private String normalizeTextFilter(String value) {
-        if (!StringUtils.hasText(value)) {
-            return null;
-        }
-        String normalized = Normalizer.normalize(value.trim(), Normalizer.Form.NFD)
-            .replaceAll(DIACRITICS_PATTERN, "");
-        return escapeLikePattern(normalized).toUpperCase(Locale.ROOT);
-    }
-
-    private String escapeLikePattern(String value) {
-        return value
-            .replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_");
+    private Specification<InvestmentOperation> operationSpecification(
+        LocalDate startDate,
+        LocalDate endDate,
+        TextSearchQuery assetQuery,
+        Long accountId,
+        InvestmentOperationType operationType,
+        Long brokerageNoteId
+    ) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (brokerageNoteId == null) {
+                predicates.add(cb.between(root.get("settlementDate"), startDate, endDate));
+            } else {
+                predicates.add(cb.equal(root.get("brokerageNote").get("id"), brokerageNoteId));
+            }
+            if (accountId != null) {
+                predicates.add(cb.equal(root.get("account").get("id"), accountId));
+            }
+            if (operationType != null) {
+                predicates.add(cb.equal(root.get("operationType"), operationType));
+            }
+            Expression<String> searchableText = cb.concat(
+                cb.concat(cb.coalesce(root.get("asset").get("name"), ""), " "),
+                cb.coalesce(root.get("asset").get("ticker"), "")
+            );
+            Predicate textPredicate = TextSearchPredicateBuilder.build(cb, searchableText, assetQuery);
+            if (textPredicate != null) {
+                predicates.add(textPredicate);
+            }
+            return cb.and(predicates.toArray(Predicate[]::new));
+        };
     }
 }

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/operation/JpaInvestmentOperationRepository.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/operation/JpaInvestmentOperationRepository.java
@@ -1,17 +1,17 @@
 package dev.ccosta.aisha.infrastructure.persistence.operation;
 
 import dev.ccosta.aisha.domain.operation.InvestmentOperation;
-import dev.ccosta.aisha.domain.operation.InvestmentOperationType;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface JpaInvestmentOperationRepository extends JpaRepository<InvestmentOperation, Long> {
+public interface JpaInvestmentOperationRepository extends JpaRepository<InvestmentOperation, Long>, JpaSpecificationExecutor<InvestmentOperation> {
 
     @EntityGraph(attributePaths = {"asset", "account"})
     java.util.List<InvestmentOperation> findAllByOrderByTradeDateAscIdAsc();
@@ -27,57 +27,8 @@ public interface JpaInvestmentOperationRepository extends JpaRepository<Investme
     java.util.List<InvestmentOperation> findAllByAssetIdOrderByTradeDateAscIdAsc(Long assetId);
 
     @EntityGraph(attributePaths = {"asset", "account", "brokerageNote"})
-    @Query(
-        """
-        select o
-        from InvestmentOperation o
-        where (:brokerageNoteId is not null or o.settlementDate between :startDate and :endDate)
-          and (:accountId is null or o.account.id = :accountId)
-          and (:operationType is null or o.operationType = :operationType)
-          and (:brokerageNoteId is null or o.brokerageNote.id = :brokerageNoteId)
-        order by o.tradeDate desc, o.id desc
-        """
-    )
-    Page<InvestmentOperation> searchByFiltersWithoutAsset(
-        @Param("startDate") LocalDate startDate,
-        @Param("endDate") LocalDate endDate,
-        @Param("accountId") Long accountId,
-        @Param("operationType") InvestmentOperationType operationType,
-        @Param("brokerageNoteId") Long brokerageNoteId,
-        Pageable pageable
-    );
-
-    @EntityGraph(attributePaths = {"asset", "account", "brokerageNote"})
-    @Query(
-        """
-        select o
-        from InvestmentOperation o
-        where (:brokerageNoteId is not null or o.settlementDate between :startDate and :endDate)
-          and (:accountId is null or o.account.id = :accountId)
-          and (:operationType is null or o.operationType = :operationType)
-          and (:brokerageNoteId is null or o.brokerageNote.id = :brokerageNoteId)
-          and (
-                :assetFilter is null
-                or upper(
-                    function(
-                        'translate',
-                        concat(coalesce(o.asset.name, ''), ' ', coalesce(o.asset.ticker, '')),
-                        'ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ',
-                        'AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn'
-                    )
-                )
-                    like concat('%', :assetFilter, '%') escape '\\'
-          )
-        order by o.tradeDate desc, o.id desc
-        """
-    )
-    Page<InvestmentOperation> searchByFilters(
-        @Param("startDate") LocalDate startDate,
-        @Param("endDate") LocalDate endDate,
-        @Param("assetFilter") String assetFilter,
-        @Param("accountId") Long accountId,
-        @Param("operationType") InvestmentOperationType operationType,
-        @Param("brokerageNoteId") Long brokerageNoteId,
+    Page<InvestmentOperation> findAll(
+        org.springframework.data.jpa.domain.Specification<InvestmentOperation> specification,
         Pageable pageable
     );
 

--- a/src/main/java/dev/ccosta/aisha/infrastructure/persistence/search/TextSearchPredicateBuilder.java
+++ b/src/main/java/dev/ccosta/aisha/infrastructure/persistence/search/TextSearchPredicateBuilder.java
@@ -1,0 +1,61 @@
+package dev.ccosta.aisha.infrastructure.persistence.search;
+
+import dev.ccosta.aisha.application.search.TextSearchQuery;
+import dev.ccosta.aisha.application.search.TextSearchTerm;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds JPA predicates for the reusable listing text search language.
+ */
+public final class TextSearchPredicateBuilder {
+
+    private static final char LIKE_ESCAPE = '\\';
+    private static final String ACCENTED_CHARACTERS = "ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇÑáàâãäéèêëíìîïóòôõöúùûüçñ";
+    private static final String ASCII_CHARACTERS = "AAAAAEEEEIIIIOOOOOUUUUCNaaaaaeeeeiiiiooooouuuucn";
+
+    private TextSearchPredicateBuilder() {
+    }
+
+    /**
+     * Creates a predicate from parsed search terms against a normalized text expression.
+     *
+     * @param cb criteria builder
+     * @param textExpression expression containing the text fields to search
+     * @param query parsed search query
+     * @return a predicate, or null when the query has no terms
+     */
+    public static Predicate build(CriteriaBuilder cb, Expression<String> textExpression, TextSearchQuery query) {
+        if (query == null || !query.hasTerms()) {
+            return null;
+        }
+
+        Expression<String> normalizedText = cb.upper(
+            cb.function(
+                "translate",
+                String.class,
+                cb.coalesce(textExpression, ""),
+                cb.literal(ACCENTED_CHARACTERS),
+                cb.literal(ASCII_CHARACTERS)
+            )
+        );
+        List<Predicate> predicates = new ArrayList<>();
+        if (!query.positiveTerms().isEmpty()) {
+            predicates.add(cb.or(query.positiveTerms().stream()
+                .map(term -> like(cb, normalizedText, term))
+                .toArray(Predicate[]::new)));
+        }
+        query.negativeTerms().stream()
+            .map(term -> cb.not(like(cb, normalizedText, term)))
+            .forEach(predicates::add);
+
+        return cb.and(predicates.toArray(Predicate[]::new));
+    }
+
+    private static Predicate like(CriteriaBuilder cb, Expression<String> text, TextSearchTerm term) {
+        return cb.like(text, term.likePattern(), LIKE_ESCAPE);
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -999,3 +999,12 @@ dashboard.accountTypeBalances.level.root=Nível: tipos de conta
 dashboard.accountTypeBalances.level.child=Nível: contas do tipo {0}
 dashboard.accountTypeBalances.error=Não foi possível carregar os saldos por tipo de conta.
 dashboard.accountTypeBalances.empty=Sem contas para exibir saldos por tipo.
+
+textSearch.help.summary=Ajuda da busca textual
+textSearch.help.intro=A busca ignora maiúsculas/minúsculas e acentuação.
+textSearch.help.orTerms=Encontra qualquer uma das palavras.
+textSearch.help.quotedPhrase=Busca a frase inteira.
+textSearch.help.negativeTerm=Exclui resultados com esse termo.
+textSearch.help.anyWildcard=Coringa para qualquer sequência.
+textSearch.help.singleWildcard=Coringa para um caractere.
+textSearch.help.escape=Pesquisa o próximo caractere literalmente.

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -966,3 +966,12 @@ dashboard.accountTypeBalances.level.root=Nível: tipos de conta
 dashboard.accountTypeBalances.level.child=Nível: contas do tipo {0}
 dashboard.accountTypeBalances.error=Não foi possível carregar os saldos por tipo de conta.
 dashboard.accountTypeBalances.empty=Sem contas para exibir saldos por tipo.
+
+textSearch.help.summary=Ajuda da busca textual
+textSearch.help.intro=A busca ignora maiúsculas/minúsculas e acentuação.
+textSearch.help.orTerms=Encontra qualquer uma das palavras.
+textSearch.help.quotedPhrase=Busca a frase inteira.
+textSearch.help.negativeTerm=Exclui resultados com esse termo.
+textSearch.help.anyWildcard=Coringa para qualquer sequência.
+textSearch.help.singleWildcard=Coringa para um caractere.
+textSearch.help.escape=Pesquisa o próximo caractere literalmente.

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -584,6 +584,84 @@ p {
   margin-top: 0;
 }
 
+.text-search-help {
+  margin-top: 0.45rem;
+}
+
+.text-search-help summary {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--secondary);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  list-style: none;
+}
+
+.text-search-help summary::-webkit-details-marker {
+  display: none;
+}
+
+.text-search-help summary:focus-visible {
+  border-radius: 8px;
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 3px;
+}
+
+.text-search-help summary .lucide {
+  width: 1rem;
+  height: 1rem;
+}
+
+.text-search-help-content {
+  display: grid;
+  gap: 0.7rem;
+  margin-top: 0.55rem;
+  padding: 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--color-action-tertiary-bg);
+}
+
+.text-search-help-content p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.text-search-help-content dl {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.text-search-help-content dl > div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.text-search-help-content dt,
+.text-search-help-content dd {
+  margin: 0;
+}
+
+.text-search-help-content code {
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  border-radius: 6px;
+  padding: 0.1rem 0.3rem;
+  background: var(--color-bg-card);
+  color: var(--text);
+  font-size: 0.88rem;
+}
+
+.text-search-help-content dd {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
 .toast-stack {
   position: fixed;
   top: max(1rem, env(safe-area-inset-top));

--- a/src/main/resources/templates/entries/list.html
+++ b/src/main/resources/templates/entries/list.html
@@ -80,6 +80,7 @@
                             type="search"
                             th:value="${selectedDescription}"
                             th:placeholder="#{entries.list.filter.description.placeholder}">
+                        <div th:replace="~{fragments/text-search-help :: textSearchHelp}"></div>
                     </div>
                     <div class="field">
                         <label for="filter-account" th:text="#{entries.list.filter.account}"></label>

--- a/src/main/resources/templates/fragments/text-search-help.html
+++ b/src/main/resources/templates/fragments/text-search-help.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="pt-BR" xmlns:th="http://www.thymeleaf.org">
+<body>
+<details th:fragment="textSearchHelp" class="text-search-help">
+    <summary>
+        <i data-lucide="circle-help" aria-hidden="true"></i>
+        <span th:text="#{textSearch.help.summary}"></span>
+    </summary>
+    <div class="text-search-help-content">
+        <p th:text="#{textSearch.help.intro}"></p>
+        <dl>
+            <div>
+                <dt><code>mercado padaria</code></dt>
+                <dd th:text="#{textSearch.help.orTerms}"></dd>
+            </div>
+            <div>
+                <dt><code>"café da manhã"</code></dt>
+                <dd th:text="#{textSearch.help.quotedPhrase}"></dd>
+            </div>
+            <div>
+                <dt><code>-ifood</code></dt>
+                <dd th:text="#{textSearch.help.negativeTerm}"></dd>
+            </div>
+            <div>
+                <dt><code>merc*</code></dt>
+                <dd th:text="#{textSearch.help.anyWildcard}"></dd>
+            </div>
+            <div>
+                <dt><code>cart?o</code></dt>
+                <dd th:text="#{textSearch.help.singleWildcard}"></dd>
+            </div>
+            <div>
+                <dt><code>\*</code> <code>\?</code></dt>
+                <dd th:text="#{textSearch.help.escape}"></dd>
+            </div>
+        </dl>
+    </div>
+</details>
+</body>
+</html>

--- a/src/main/resources/templates/investments/assets/list.html
+++ b/src/main/resources/templates/investments/assets/list.html
@@ -64,6 +64,7 @@
                             type="search"
                             th:value="${selectedDescription}"
                             th:placeholder="#{investments.assets.list.filter.description.placeholder}">
+                        <div th:replace="~{fragments/text-search-help :: textSearchHelp}"></div>
                     </div>
                 </div>
                 <input type="hidden" name="page" value="0">

--- a/src/main/resources/templates/investments/brokerage-notes/list.html
+++ b/src/main/resources/templates/investments/brokerage-notes/list.html
@@ -62,6 +62,7 @@
                             type="search"
                             th:value="${selectedNoteNumber}"
                             th:placeholder="#{investments.brokerageNotes.list.filter.noteNumber.placeholder}">
+                        <div th:replace="~{fragments/text-search-help :: textSearchHelp}"></div>
                     </div>
                     <div class="field">
                         <label for="filter-trade-start" th:text="#{investments.brokerageNotes.list.filter.tradeStartDate}"></label>

--- a/src/main/resources/templates/investments/operations/list.html
+++ b/src/main/resources/templates/investments/operations/list.html
@@ -58,6 +58,7 @@
                             type="search"
                             th:value="${selectedAsset}"
                             th:placeholder="#{investments.operations.list.filter.asset.placeholder}">
+                        <div th:replace="~{fragments/text-search-help :: textSearchHelp}"></div>
                     </div>
                     <div class="field">
                         <label for="filter-account" th:text="#{investments.operations.list.filter.account}"></label>

--- a/src/test/java/dev/ccosta/aisha/application/search/TextSearchQueryParserTest.java
+++ b/src/test/java/dev/ccosta/aisha/application/search/TextSearchQueryParserTest.java
@@ -1,0 +1,46 @@
+package dev.ccosta.aisha.application.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TextSearchQueryParserTest {
+
+    private final TextSearchQueryParser parser = new TextSearchQueryParser();
+
+    @Test
+    void shouldParsePositiveTermsAsOrCandidates() {
+        TextSearchQuery query = parser.parse("mercado padaria");
+
+        assertThat(query.positiveTerms())
+            .extracting(TextSearchTerm::likePattern)
+            .containsExactly("%MERCADO%", "%PADARIA%");
+        assertThat(query.negativeTerms()).isEmpty();
+    }
+
+    @Test
+    void shouldParseQuotedPhrasesAndNegativeTerms() {
+        TextSearchQuery query = parser.parse("\"café da manhã\" -ifood");
+
+        assertThat(query.positiveTerms())
+            .extracting(TextSearchTerm::likePattern)
+            .containsExactly("%CAFE DA MANHA%");
+        assertThat(query.negativeTerms())
+            .extracting(TextSearchTerm::likePattern)
+            .containsExactly("%IFOOD%");
+    }
+
+    @Test
+    void shouldConvertUnescapedWildcardsAndEscapeLiteralLikeCharacters() {
+        TextSearchQuery query = parser.parse("caf* cart?o taxa\\* valor\\? a\\_b 100\\%");
+
+        assertThat(query.positiveTerms())
+            .extracting(TextSearchTerm::likePattern)
+            .containsExactly("%CAF%%", "%CART_O%", "%TAXA*%", "%VALOR?%", "%A\\_B%", "%100\\%%");
+    }
+
+    @Test
+    void shouldReturnEmptyQueryForBlankInput() {
+        assertThat(parser.parse("   ").hasTerms()).isFalse();
+    }
+}

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/asset/AssetRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/asset/AssetRepositoryAdapterTest.java
@@ -1,22 +1,18 @@
 package dev.ccosta.aisha.infrastructure.persistence.asset;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import dev.ccosta.aisha.domain.asset.AssetType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 class AssetRepositoryAdapterTest {
@@ -28,34 +24,22 @@ class AssetRepositoryAdapterTest {
     private AssetRepositoryAdapter assetRepositoryAdapter;
 
     @Test
-    void shouldNormalizeDescriptionFilterBeforeQuerying() {
-        when(jpaAssetRepository.searchByFilters(nullable(AssetType.class), anyString(), any(Pageable.class)))
-            .thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecification() {
+        when(jpaAssetRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         assetRepositoryAdapter.findPageOrdered(AssetType.STOCK, "Ação_100%", 0, 25);
 
-        ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
-        verify(jpaAssetRepository).searchByFilters(
-            nullable(AssetType.class),
-            descriptionCaptor.capture(),
-            any(Pageable.class)
-        );
-
-        assertThat(descriptionCaptor.getValue()).isEqualTo("ACAO\\_100\\%");
+        verify(jpaAssetRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 
     @Test
-    void shouldUseQueryWithoutDescriptionWhenFilterIsBlank() {
-        when(jpaAssetRepository.searchByFiltersWithoutDescription(nullable(AssetType.class), any(Pageable.class)))
-            .thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecificationWhenFilterIsBlank() {
+        when(jpaAssetRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         assetRepositoryAdapter.findPageOrdered(AssetType.STOCK, "   ", 0, 25);
 
-        verify(jpaAssetRepository).searchByFiltersWithoutDescription(nullable(AssetType.class), any(Pageable.class));
-        verify(jpaAssetRepository, never()).searchByFilters(
-            nullable(AssetType.class),
-            anyString(),
-            any(Pageable.class)
-        );
+        verify(jpaAssetRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 }

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/brokeragenote/BrokerageNoteRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/brokeragenote/BrokerageNoteRepositoryAdapterTest.java
@@ -1,22 +1,18 @@
 package dev.ccosta.aisha.infrastructure.persistence.brokeragenote;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 class BrokerageNoteRepositoryAdapterTest {
@@ -28,16 +24,9 @@ class BrokerageNoteRepositoryAdapterTest {
     private BrokerageNoteRepositoryAdapter brokerageNoteRepositoryAdapter;
 
     @Test
-    void shouldNormalizeNoteNumberPrefixBeforeQuerying() {
-        when(jpaBrokerageNoteRepository.searchByFilters(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            nullable(Long.class),
-            nullable(LocalDate.class),
-            nullable(LocalDate.class),
-            anyString(),
-            any(Pageable.class)
-        )).thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecification() {
+        when(jpaBrokerageNoteRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         brokerageNoteRepositoryAdapter.findPageOrdered(
             LocalDate.of(2026, 1, 1),
@@ -50,30 +39,13 @@ class BrokerageNoteRepositoryAdapterTest {
             25
         );
 
-        ArgumentCaptor<String> noteNumberCaptor = ArgumentCaptor.forClass(String.class);
-        verify(jpaBrokerageNoteRepository).searchByFilters(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            nullable(Long.class),
-            nullable(LocalDate.class),
-            nullable(LocalDate.class),
-            noteNumberCaptor.capture(),
-            any(Pageable.class)
-        );
-
-        assertThat(noteNumberCaptor.getValue()).isEqualTo("NT\\_100\\%");
+        verify(jpaBrokerageNoteRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 
     @Test
-    void shouldUseQueryWithoutNoteNumberWhenFilterIsBlank() {
-        when(jpaBrokerageNoteRepository.searchByFiltersWithoutNoteNumber(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            nullable(Long.class),
-            nullable(LocalDate.class),
-            nullable(LocalDate.class),
-            any(Pageable.class)
-        )).thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecificationWhenFilterIsBlank() {
+        when(jpaBrokerageNoteRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         brokerageNoteRepositoryAdapter.findPageOrdered(
             LocalDate.of(2026, 1, 1),
@@ -86,22 +58,6 @@ class BrokerageNoteRepositoryAdapterTest {
             25
         );
 
-        verify(jpaBrokerageNoteRepository).searchByFiltersWithoutNoteNumber(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            nullable(Long.class),
-            nullable(LocalDate.class),
-            nullable(LocalDate.class),
-            any(Pageable.class)
-        );
-        verify(jpaBrokerageNoteRepository, never()).searchByFilters(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            nullable(Long.class),
-            nullable(LocalDate.class),
-            nullable(LocalDate.class),
-            anyString(),
-            any(Pageable.class)
-        );
+        verify(jpaBrokerageNoteRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 }

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/EntryRepositoryAdapterTest.java
@@ -1,23 +1,18 @@
 package dev.ccosta.aisha.infrastructure.persistence.entry;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import dev.ccosta.aisha.domain.entry.categorization.EntryCategorySuggestionStatus;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 class EntryRepositoryAdapterTest {
@@ -29,18 +24,9 @@ class EntryRepositoryAdapterTest {
     private EntryRepositoryAdapter entryRepositoryAdapter;
 
     @Test
-    void shouldNormalizeDescriptionFilterBeforeQuerying() {
-        when(jpaEntryRepository.searchBySettlementDateBetweenAndFilters(
-            any(),
-            any(),
-            anyLong(),
-            anyLong(),
-            anyString(),
-            anyBoolean(),
-            anyBoolean(),
-            any(EntryCategorySuggestionStatus.class),
-            any(Pageable.class)
-        )).thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecification() {
+        when(jpaEntryRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         entryRepositoryAdapter.listMostRecentBySettlementDateBetweenAndFilters(
             LocalDate.of(2026, 1, 1),
@@ -54,34 +40,13 @@ class EntryRepositoryAdapterTest {
             25
         );
 
-        ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
-        verify(jpaEntryRepository).searchBySettlementDateBetweenAndFilters(
-            any(),
-            any(),
-            anyLong(),
-            anyLong(),
-            descriptionCaptor.capture(),
-            anyBoolean(),
-            anyBoolean(),
-            any(EntryCategorySuggestionStatus.class),
-            any(Pageable.class)
-        );
-
-        org.assertj.core.api.Assertions.assertThat(descriptionCaptor.getValue()).isEqualTo("CAFE\\_100\\%");
+        verify(jpaEntryRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 
     @Test
-    void shouldUseQueryWithoutDescriptionWhenFilterIsBlank() {
-        when(jpaEntryRepository.searchBySettlementDateBetweenAndFiltersWithoutDescription(
-            any(),
-            any(),
-            anyLong(),
-            anyLong(),
-            anyBoolean(),
-            anyBoolean(),
-            any(EntryCategorySuggestionStatus.class),
-            any(Pageable.class)
-        )).thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecificationWhenFilterIsBlank() {
+        when(jpaEntryRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         entryRepositoryAdapter.listMostRecentBySettlementDateBetweenAndFilters(
             LocalDate.of(2026, 1, 1),
@@ -95,26 +60,6 @@ class EntryRepositoryAdapterTest {
             25
         );
 
-        verify(jpaEntryRepository).searchBySettlementDateBetweenAndFiltersWithoutDescription(
-            any(),
-            any(),
-            anyLong(),
-            anyLong(),
-            anyBoolean(),
-            anyBoolean(),
-            any(EntryCategorySuggestionStatus.class),
-            any(Pageable.class)
-        );
-        verify(jpaEntryRepository, never()).searchBySettlementDateBetweenAndFilters(
-            any(),
-            any(),
-            anyLong(),
-            anyLong(),
-            anyString(),
-            anyBoolean(),
-            anyBoolean(),
-            any(EntryCategorySuggestionStatus.class),
-            any(Pageable.class)
-        );
+        verify(jpaEntryRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 }

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepositoryTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/entry/JpaEntryRepositoryTest.java
@@ -6,14 +6,13 @@ import dev.ccosta.aisha.domain.account.Account;
 import dev.ccosta.aisha.domain.category.Category;
 import dev.ccosta.aisha.domain.entry.Entry;
 import dev.ccosta.aisha.domain.entry.categorization.EntryCategorySuggestionStatus;
+import dev.ccosta.aisha.domain.shared.PagedResult;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 class JpaEntryRepositoryTest {
 
     @Autowired
-    private JpaEntryRepository jpaEntryRepository;
+    private EntryRepositoryAdapter entryRepositoryAdapter;
 
     @Autowired
     private EntityManager entityManager;
@@ -37,19 +36,73 @@ class JpaEntryRepositoryTest {
         entityManager.flush();
         entityManager.clear();
 
-        Page<Entry> result = jpaEntryRepository.searchBySettlementDateBetweenAndFilters(
+        PagedResult<Entry> result = entryRepositoryAdapter.listMostRecentBySettlementDateBetweenAndFilters(
             LocalDate.of(2026, 1, 1),
             LocalDate.of(2026, 1, 31),
             null,
             null,
-            "CAFE",
+            "cafe",
             false,
             false,
-            EntryCategorySuggestionStatus.PENDING,
-            PageRequest.of(0, 25)
+            0,
+            25
         );
 
-        assertThat(result.getContent())
+        assertThat(result.items())
+            .extracting(Entry::getId)
+            .containsExactly(matchingEntry.getId());
+    }
+
+    @Test
+    void shouldApplyAdvancedDescriptionSearchSyntax() {
+        Account account = persistAccount("Conta teste");
+        Category category = persistCategory("Categoria teste");
+        Entry mercado = persistEntry(account, category, "Mercado bairro");
+        Entry farmacia = persistEntry(account, category, "Farmácia centro");
+        persistEntry(account, category, "Mercado ifood");
+        persistEntry(account, category, "Padaria");
+        entityManager.flush();
+        entityManager.clear();
+
+        PagedResult<Entry> result = entryRepositoryAdapter.listMostRecentBySettlementDateBetweenAndFilters(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            account.getId(),
+            null,
+            "merc* farm?cia -ifood",
+            false,
+            false,
+            0,
+            25
+        );
+
+        assertThat(result.items())
+            .extracting(Entry::getId)
+            .containsExactly(farmacia.getId(), mercado.getId());
+    }
+
+    @Test
+    void shouldApplyQuotedDescriptionSearchPhrase() {
+        Account account = persistAccount("Conta teste");
+        Category category = persistCategory("Categoria teste");
+        Entry matchingEntry = persistEntry(account, category, "Café da manhã");
+        persistEntry(account, category, "Café no mercado pela manhã");
+        entityManager.flush();
+        entityManager.clear();
+
+        PagedResult<Entry> result = entryRepositoryAdapter.listMostRecentBySettlementDateBetweenAndFilters(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            account.getId(),
+            null,
+            "\"cafe da manha\"",
+            false,
+            false,
+            0,
+            25
+        );
+
+        assertThat(result.items())
             .extracting(Entry::getId)
             .containsExactly(matchingEntry.getId());
     }
@@ -64,18 +117,19 @@ class JpaEntryRepositoryTest {
         entityManager.flush();
         entityManager.clear();
 
-        Page<Entry> result = jpaEntryRepository.searchBySettlementDateBetweenAndFiltersWithoutDescription(
+        PagedResult<Entry> result = entryRepositoryAdapter.listMostRecentBySettlementDateBetweenAndFilters(
             LocalDate.of(2026, 1, 1),
             LocalDate.of(2026, 1, 31),
             account.getId(),
             null,
+            "   ",
             false,
             false,
-            EntryCategorySuggestionStatus.PENDING,
-            PageRequest.of(0, 25)
+            0,
+            25
         );
 
-        assertThat(result.getContent())
+        assertThat(result.items())
             .extracting(Entry::getId)
             .containsExactly(newerEntry.getId(), olderEntry.getId());
     }

--- a/src/test/java/dev/ccosta/aisha/infrastructure/persistence/operation/InvestmentOperationRepositoryAdapterTest.java
+++ b/src/test/java/dev/ccosta/aisha/infrastructure/persistence/operation/InvestmentOperationRepositoryAdapterTest.java
@@ -1,10 +1,6 @@
 package dev.ccosta.aisha.infrastructure.persistence.operation;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -12,12 +8,12 @@ import dev.ccosta.aisha.domain.operation.InvestmentOperationType;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 class InvestmentOperationRepositoryAdapterTest {
@@ -29,16 +25,9 @@ class InvestmentOperationRepositoryAdapterTest {
     private InvestmentOperationRepositoryAdapter investmentOperationRepositoryAdapter;
 
     @Test
-    void shouldNormalizeAssetFilterBeforeQuerying() {
-        when(jpaInvestmentOperationRepository.searchByFilters(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            anyString(),
-            nullable(Long.class),
-            nullable(InvestmentOperationType.class),
-            nullable(Long.class),
-            any(Pageable.class)
-        )).thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecification() {
+        when(jpaInvestmentOperationRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         investmentOperationRepositoryAdapter.findPageOrdered(
             LocalDate.of(2026, 1, 1),
@@ -51,30 +40,13 @@ class InvestmentOperationRepositoryAdapterTest {
             25
         );
 
-        ArgumentCaptor<String> assetFilterCaptor = ArgumentCaptor.forClass(String.class);
-        verify(jpaInvestmentOperationRepository).searchByFilters(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            assetFilterCaptor.capture(),
-            nullable(Long.class),
-            nullable(InvestmentOperationType.class),
-            nullable(Long.class),
-            any(Pageable.class)
-        );
-
-        assertThat(assetFilterCaptor.getValue()).isEqualTo("ACAO\\_100\\%");
+        verify(jpaInvestmentOperationRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 
     @Test
-    void shouldUseQueryWithoutAssetWhenFilterIsBlank() {
-        when(jpaInvestmentOperationRepository.searchByFiltersWithoutAsset(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            nullable(Long.class),
-            nullable(InvestmentOperationType.class),
-            nullable(Long.class),
-            any(Pageable.class)
-        )).thenReturn(Page.empty());
+    @SuppressWarnings("unchecked")
+    void shouldQueryUsingSpecificationWhenFilterIsBlank() {
+        when(jpaInvestmentOperationRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(Page.empty());
 
         investmentOperationRepositoryAdapter.findPageOrdered(
             LocalDate.of(2026, 1, 1),
@@ -87,22 +59,6 @@ class InvestmentOperationRepositoryAdapterTest {
             25
         );
 
-        verify(jpaInvestmentOperationRepository).searchByFiltersWithoutAsset(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            nullable(Long.class),
-            nullable(InvestmentOperationType.class),
-            nullable(Long.class),
-            any(Pageable.class)
-        );
-        verify(jpaInvestmentOperationRepository, never()).searchByFilters(
-            any(LocalDate.class),
-            any(LocalDate.class),
-            anyString(),
-            nullable(Long.class),
-            nullable(InvestmentOperationType.class),
-            nullable(Long.class),
-            any(Pageable.class)
-        );
+        verify(jpaInvestmentOperationRepository).findAll(any(Specification.class), any(Pageable.class));
     }
 }


### PR DESCRIPTION
## Summary
- Add a reusable parser for the listing text search syntax with quoted phrases, OR terms, exclusions, escaping, and `*`/`?` wildcards.
- Reuse the parser across textual filters in entries, assets, investment operations, and brokerage notes.
- Add an expandable help fragment in listing filters explaining the syntax in pt-BR.

## Validation
- `./mvnw test`